### PR TITLE
fix: update readme and root.go

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ These instructions will help you set up and run `vault-audit-filter` on your loc
 
 ### Prerequisites
 
-- **Go**: Ensure you have Go 1.22.3 or later installed. You can download it here: <https://golang.org/dl/>
+- **Go**: Ensure you have Go 1.25.5 or later installed. You can download it here: <https://golang.org/dl/>
 - **Vault**: You should have HashiCorp Vault installed and configured. Instructions can be found here: <https://www.vaultproject.io/docs/install>
 
 ### Installation
@@ -143,16 +143,34 @@ Rules are written using the `expr` language, a simple and safe expression langua
 
 ## Usage
 
-To run `vault-audit-filter` with your configuration file, use:
+`vault-audit-filter` provides two subcommands:
+
+### Setup Vault Audit Device
+
+Configure Vault to send audit logs to this service:
 
 ```bash
-$ ./vault-audit-filter --config config.yaml
+./vault-audit-filter setup --config config.yaml
+```
+
+### Start the Audit Server
+
+Start the UDP server to receive and filter Vault audit logs:
+
+```bash
+./vault-audit-filter auditServer --config config.yaml
 ```
 
 ### Command-Line Options
 
-- `--config`: Specify the path to the configuration file (default is `config.yaml`).
-- `--log-level`: Set the logging level (`debug`, `info`, `warn`, `error`).
+**Global flags:**
+
+- `--config`: Specify the path to the configuration file (default is `$HOME/.vault-audit-filter.yaml`).
+- `--vault.address`: Vault server address (default: `http://127.0.0.1:8200`).
+- `--vault.token`: Vault authentication token.
+- `--vault.audit_path`: Path for the Vault audit device (default: `/vault-audit-filter`).
+- `--vault.audit_address`: Address for receiving audit logs (default: `127.0.0.1:1269`).
+- `--vault.audit_description`: Description for the Vault audit device.
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![codecov](https://codecov.io/gh/ncode/vault-audit-filter/graph/badge.svg?token=PTW9OYF19R)](https://codecov.io/gh/ncode/vault-audit-filter)
 
-`vault-audit-filter` is a Go-based tool designed to filter and log HashiCorp Vault audit logs based on configurable rules. It provides fine-grained control over how Vault audit events are processed and categorized, allowing you to capture critical events while reducing noise from routine operations.
+`vault-audit-filter` is designed to filter and log HashiCorp Vault audit logs based on configurable rules. It provides fine-grained control over how Vault audit events are processed and categorized, allowing you to capture critical events while reducing noise from routine operations.
 
 ## Features
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,16 +35,14 @@ var cfgFile string
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "vault-audit-filter",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
-examples and usage of using your application. For example:
+	Short: "Filter and log HashiCorp Vault audit logs based on configurable rules",
+	Long: `vault-audit-filter is a tool designed to filter and log HashiCorp Vault
+audit logs based on configurable rules. It provides fine-grained control over
+how Vault audit events are processed and categorized, allowing you to capture
+critical events while reducing noise from routine operations.
 
-Cobra is a CLI library for Go that empowers applications.
-This application is a tool to generate the needed files
-to quickly create a Cobra application.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
+Use 'setup' to configure Vault to send audit logs to this service.
+Use 'auditServer' to start the UDP server that receives and filters logs.`,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
This pull request updates the documentation and command descriptions for `vault-audit-filter` to clarify usage and improve instructions. The main focus is on making it easier for users to understand how to set up and run the tool, as well as providing more accurate information about its requirements and capabilities.

Documentation and usage improvements:

* Updated the Go version requirement in `README.md` from 1.22.3 to 1.25.5 to reflect the current minimum supported version.
* Expanded the usage section in `README.md` to describe the two main subcommands (`setup` and `auditServer`), including example commands and detailed explanations of global flags.
* Improved the command description in `cmd/root.go` to provide a clear and concise explanation of the tool's purpose and usage, replacing placeholder text with meaningful documentation.