### PR TITLE
Make message and forward async to avoid contention and losing logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ go.work.sum
 
 # ignore the log directory
 configs/development/logs/
+.worktrees/

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Once you have built the project, you can run the `vault-audit-filter` executable
 
     async:
       queue_size: 20
+      workers: 2
       timeout: 5s
 
     rule_groups:
@@ -135,7 +136,61 @@ Once you have built the project, you can run the `vault-audit-filter` executable
 
   - **Async Settings**:
   - `async.queue_size`: Bounded queue length for async side effects (drop on full).
+  - `async.workers`: Number of async side-effect workers (`0` disables worker execution).
   - `async.timeout`: Timeout for Slack API/webhook and forwarding operations.
+
+### Async Tuning Profiles
+
+Use these as baseline profiles and tune from there:
+
+| Profile | `async.queue_size` | `async.workers` | `async.timeout` | Expected Behavior |
+| --- | ---: | ---: | --- | --- |
+| Latency-first (default) | 20 | 2 | 5s | Lowest request latency; highest drop risk during bursts |
+| Balanced | 256 | 8 | 5s | Low request latency with lower drop rate than default |
+| Throughput-biased | 1024 | 16 | 5s | Low request latency with significantly fewer drops; higher CPU/memory usage |
+
+Representative stress-test results (2000 requests, concurrency 64, slow downstream side effects):
+
+| Config | Downstream Delay | Request Avg | Request P95 | Inferred Drops |
+| --- | ---: | ---: | ---: | ---: |
+| Sync (`main`) | 20ms | 21.0ms | 21.4ms | 0 |
+| Async `q=64,w=2` | 20ms | 0.30ms | 1.06ms | 1934/2000 |
+| Async `q=256,w=8` | 20ms | 0.34ms | 1.39ms | 1736/2000 |
+| Async `q=1024,w=16` | 20ms | 0.37ms | 1.80ms | 960/2000 |
+
+Interpretation:
+- Current async design is appropriate when request-path latency protection is the top priority.
+- If side-effect delivery reliability is required, increase queue/workers and monitor drops, or move to a durable retry design.
+
+### Performance Findings and Decision
+
+Performance findings from the latest comparison are:
+- Synchronous mode (`main`) preserves side-effect delivery in the test scenario, but request latency tracks downstream delay (about 21ms average at 20ms downstream delay).
+- Asynchronous mode keeps request latency low (sub-millisecond average in measured scenarios), but can drop a large fraction of side effects during bursts depending on queue/workers settings.
+
+Caveats:
+- The numbers above come from synthetic stress tests (2000 requests, concurrency 64) and are intended as directional guidance.
+- Real production behavior depends on traffic burst shape, downstream service health, and host resource limits.
+
+Current decision:
+- Operate in latency-first async mode by default.
+- Treat side effects as best-effort unless deployment requirements explicitly demand stronger delivery guarantees.
+
+When durable/retry work is needed:
+- Side-effect drops remain sustained and unacceptable after tuning `async.workers` and `async.queue_size`.
+- Audit/operational requirements require stronger guarantees than best-effort delivery.
+
+Follow-up options:
+1. Add bounded blocking enqueue mode to trade some request latency for fewer drops.
+2. Add durable retry and dead-letter flow for stronger side-effect delivery guarantees.
+3. Re-run workload-specific tuning tests and adjust profile recommendations.
+
+Tuning checklist:
+1. Start with `Latency-first` or `Balanced`.
+2. Monitor side-effect drop count and request tail latency.
+3. If drops are sustained and unacceptable, raise `async.workers` first, then `async.queue_size`.
+4. If request tail latency regresses, reduce workers or move to a balanced profile.
+5. If drops remain unacceptable, adopt durable retry architecture rather than unbounded tuning.
 
 ### Rule Syntax
 

--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ Once you have built the project, you can run the `vault-audit-filter` executable
       audit_address: "127.0.0.1:1269"
       audit_description: "Vault Audit Filter Device"
 
+    async:
+      queue_size: 20
+      timeout: 5s
+
     rule_groups:
       - name: "normal_operations"
         rules:
@@ -128,6 +132,10 @@ Once you have built the project, you can run the `vault-audit-filter` executable
   - `messaging.url`: The Slack API base URL (when using "slack" type).
   - `messaging.token`: The bot token for Slack (when using "slack" type).
   - `messaging.channel`: The channel ID for Slack messages (when using "slack" type).
+
+  - **Async Settings**:
+  - `async.queue_size`: Bounded queue length for async side effects (drop on full).
+  - `async.timeout`: Timeout for Slack API/webhook and forwarding operations.
 
 ### Rule Syntax
 

--- a/configs/development/config/config.yaml
+++ b/configs/development/config/config.yaml
@@ -1,3 +1,8 @@
+async:
+  queue_size: 20
+  workers: 2
+  timeout: 5s
+
 rule_groups:
   - name: "normal_operations"
     rules:

--- a/pkg/auditserver/async.go
+++ b/pkg/auditserver/async.go
@@ -1,6 +1,9 @@
 package auditserver
 
 import (
+	"strconv"
+	"time"
+
 	"github.com/ncode/vault-audit-filter/pkg/forwarder"
 	"github.com/ncode/vault-audit-filter/pkg/messaging"
 )
@@ -8,6 +11,9 @@ import (
 var defaultSideWorkers = 2
 
 type sideTask struct {
+	id         string
+	groupName  string
+	attempts   int
 	payload    []byte
 	payloadStr string
 	messenger  messaging.Messenger
@@ -15,13 +21,56 @@ type sideTask struct {
 }
 
 func (as *AuditServer) enqueueSide(task sideTask) bool {
+	if as.asyncDurableEnabled && as.sideStore != nil {
+		if task.id == "" {
+			task.id = as.nextSideTaskID()
+		}
+		if err := as.sideStore.Save(task); err != nil {
+			as.logger.Error("Failed to persist durable side task", "error", err)
+			return false
+		}
+	}
+
+	if as.asyncEnqueueMode == "wait" {
+		timeout := as.asyncEnqueueTimeout
+		if timeout <= 0 {
+			timeout = 5 * time.Millisecond
+		}
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		select {
+		case as.sideQueue <- task:
+			return true
+		case <-timer.C:
+			if as.asyncDurableEnabled {
+				time.AfterFunc(as.asyncRetryBackoff, func() {
+					_ = as.enqueueSide(task)
+				})
+				return true
+			}
+			as.sideDrops.Add(1)
+			return false
+		}
+	}
+
 	select {
 	case as.sideQueue <- task:
 		return true
 	default:
+		if as.asyncDurableEnabled {
+			time.AfterFunc(as.asyncRetryBackoff, func() {
+				_ = as.enqueueSide(task)
+			})
+			return true
+		}
 		as.sideDrops.Add(1)
 		return false
 	}
+}
+
+func (as *AuditServer) nextSideTaskID() string {
+	n := as.sideTaskSeq.Add(1)
+	return time.Now().Format("20060102150405.000000000") + "-" + strconv.FormatUint(n, 10)
 }
 
 func (as *AuditServer) startSideWorkers(n int) {
@@ -31,17 +80,65 @@ func (as *AuditServer) startSideWorkers(n int) {
 	for i := 0; i < n; i++ {
 		go func() {
 			for task := range as.sideQueue {
-				if task.messenger != nil {
-					if err := task.messenger.Send(task.payloadStr); err != nil {
-						as.logger.Error("Failed to send notification", "error", err)
-					}
-				}
-				if task.forwarder != nil {
-					if err := task.forwarder.Forward(task.payload); err != nil {
-						as.logger.Error("Failed to forward message", "error", err)
-					}
-				}
+				as.processSideTask(task)
 			}
 		}()
 	}
+}
+
+func (as *AuditServer) processSideTask(task sideTask) {
+	messenger := task.messenger
+	fwd := task.forwarder
+	if task.groupName != "" {
+		for i := range as.ruleGroups {
+			if as.ruleGroups[i].Name == task.groupName {
+				if messenger == nil {
+					messenger = as.ruleGroups[i].Messenger
+				}
+				if fwd == nil {
+					fwd = as.ruleGroups[i].Forwarder
+				}
+				break
+			}
+		}
+	}
+
+	var sendErr error
+	if messenger != nil {
+		if err := messenger.Send(task.payloadStr); err != nil {
+			as.logger.Error("Failed to send notification", "error", err)
+			sendErr = err
+		}
+	}
+	if fwd != nil {
+		if err := fwd.Forward(task.payload); err != nil {
+			as.logger.Error("Failed to forward message", "error", err)
+			if sendErr == nil {
+				sendErr = err
+			}
+		}
+	}
+
+	if !as.asyncDurableEnabled || as.sideStore == nil || task.id == "" {
+		return
+	}
+
+	if sendErr == nil {
+		_ = as.sideStore.Delete(task.id)
+		return
+	}
+
+	task.attempts++
+	if task.attempts >= as.asyncRetryMaxAttempts {
+		_ = as.sideStore.MoveToDeadLetter(task, sendErr.Error())
+		_ = as.sideStore.Delete(task.id)
+		return
+	}
+
+	if err := as.sideStore.Save(task); err != nil {
+		as.logger.Error("Failed to save retry side task", "error", err)
+	}
+	time.AfterFunc(as.asyncRetryBackoff, func() {
+		_ = as.enqueueSide(task)
+	})
 }

--- a/pkg/auditserver/async.go
+++ b/pkg/auditserver/async.go
@@ -1,0 +1,47 @@
+package auditserver
+
+import (
+	"github.com/ncode/vault-audit-filter/pkg/forwarder"
+	"github.com/ncode/vault-audit-filter/pkg/messaging"
+)
+
+var defaultSideWorkers = 2
+
+type sideTask struct {
+	payload    []byte
+	payloadStr string
+	messenger  messaging.Messenger
+	forwarder  forwarder.Forwarder
+}
+
+func (as *AuditServer) enqueueSide(task sideTask) bool {
+	select {
+	case as.sideQueue <- task:
+		return true
+	default:
+		as.sideDrops.Add(1)
+		return false
+	}
+}
+
+func (as *AuditServer) startSideWorkers(n int) {
+	if n <= 0 {
+		return
+	}
+	for i := 0; i < n; i++ {
+		go func() {
+			for task := range as.sideQueue {
+				if task.messenger != nil {
+					if err := task.messenger.Send(task.payloadStr); err != nil {
+						as.logger.Error("Failed to send notification", "error", err)
+					}
+				}
+				if task.forwarder != nil {
+					if err := task.forwarder.Forward(task.payload); err != nil {
+						as.logger.Error("Failed to forward message", "error", err)
+					}
+				}
+			}
+		}()
+	}
+}

--- a/pkg/auditserver/bench_test.go
+++ b/pkg/auditserver/bench_test.go
@@ -1,0 +1,43 @@
+package auditserver
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/expr-lang/expr"
+	"github.com/spf13/viper"
+)
+
+func BenchmarkReact(b *testing.B) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	viper.Reset()
+	viper.Set("rule_groups", []map[string]interface{}{
+		{
+			"name": "rg",
+			"rules": []string{"true"},
+			"log_file": map[string]interface{}{
+				"file_path": "/tmp/test.log",
+				"max_size":  1,
+			},
+		},
+	})
+	server, _ := New(logger)
+	frame := []byte(`{"type":"request","time":"2000-01-01T00:00:00Z","auth":{},"request":{},"response":{}}`)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		server.React(frame, nil)
+	}
+}
+
+func BenchmarkShouldLog(b *testing.B) {
+	p, _ := expr.Compile("true", expr.Env(&AuditLog{}))
+	rg := &RuleGroup{CompiledRules: []CompiledRule{{Program: p}}}
+	al := &AuditLog{}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = rg.shouldLog(al)
+	}
+}

--- a/pkg/auditserver/durable.go
+++ b/pkg/auditserver/durable.go
@@ -36,6 +36,14 @@ type deadLetterTask struct {
 	Reason    string            `json:"reason"`
 }
 
+var marshalPersistedSideTask = func(p persistedSideTask) ([]byte, error) {
+	return json.Marshal(p)
+}
+
+var marshalDeadLetterTask = func(d deadLetterTask) ([]byte, error) {
+	return json.Marshal(d)
+}
+
 func newFileSideTaskStore(baseDir string) (*fileSideTaskStore, error) {
 	pendingDir := filepath.Join(baseDir, "pending")
 	deadDir := filepath.Join(baseDir, "deadletter")
@@ -61,7 +69,7 @@ func (s *fileSideTaskStore) Save(task sideTask) error {
 		Payload:    task.payload,
 		PayloadStr: task.payloadStr,
 	}
-	b, err := json.Marshal(p)
+	b, err := marshalPersistedSideTask(p)
 	if err != nil {
 		return err
 	}
@@ -97,7 +105,7 @@ func (s *fileSideTaskStore) MoveToDeadLetter(task sideTask, reason string) error
 		},
 		Reason: reason,
 	}
-	b, err := json.Marshal(d)
+	b, err := marshalDeadLetterTask(d)
 	if err != nil {
 		return err
 	}

--- a/pkg/auditserver/durable.go
+++ b/pkg/auditserver/durable.go
@@ -1,0 +1,155 @@
+package auditserver
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+type sideTaskStore interface {
+	Save(task sideTask) error
+	Delete(id string) error
+	MoveToDeadLetter(task sideTask, reason string) error
+	Pending() ([]sideTask, error)
+}
+
+type fileSideTaskStore struct {
+	baseDir    string
+	pendingDir string
+	deadDir    string
+	mu         sync.Mutex
+}
+
+type persistedSideTask struct {
+	ID         string `json:"id"`
+	GroupName  string `json:"group_name"`
+	Attempts   int    `json:"attempts"`
+	Payload    []byte `json:"payload"`
+	PayloadStr string `json:"payload_str"`
+}
+
+type deadLetterTask struct {
+	Persisted persistedSideTask `json:"persisted"`
+	Reason    string            `json:"reason"`
+}
+
+func newFileSideTaskStore(baseDir string) (*fileSideTaskStore, error) {
+	pendingDir := filepath.Join(baseDir, "pending")
+	deadDir := filepath.Join(baseDir, "deadletter")
+	if err := os.MkdirAll(pendingDir, 0o755); err != nil {
+		return nil, err
+	}
+	if err := os.MkdirAll(deadDir, 0o755); err != nil {
+		return nil, err
+	}
+	return &fileSideTaskStore{baseDir: baseDir, pendingDir: pendingDir, deadDir: deadDir}, nil
+}
+
+func (s *fileSideTaskStore) Save(task sideTask) error {
+	if task.id == "" {
+		return fmt.Errorf("empty task id")
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	p := persistedSideTask{
+		ID:         task.id,
+		GroupName:  task.groupName,
+		Attempts:   task.attempts,
+		Payload:    task.payload,
+		PayloadStr: task.payloadStr,
+	}
+	b, err := json.Marshal(p)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(s.pendingDir, task.id+".json"), b, 0o600)
+}
+
+func (s *fileSideTaskStore) Delete(id string) error {
+	if id == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	err := os.Remove(filepath.Join(s.pendingDir, id+".json"))
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+func (s *fileSideTaskStore) MoveToDeadLetter(task sideTask, reason string) error {
+	if task.id == "" {
+		return nil
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	d := deadLetterTask{
+		Persisted: persistedSideTask{
+			ID:         task.id,
+			GroupName:  task.groupName,
+			Attempts:   task.attempts,
+			Payload:    task.payload,
+			PayloadStr: task.payloadStr,
+		},
+		Reason: reason,
+	}
+	b, err := json.Marshal(d)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(s.deadDir, task.id+".json"), b, 0o600)
+}
+
+func (s *fileSideTaskStore) Pending() ([]sideTask, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entries, err := os.ReadDir(s.pendingDir)
+	if err != nil {
+		return nil, err
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	tasks := make([]sideTask, 0, len(names))
+	for _, name := range names {
+		b, err := os.ReadFile(filepath.Join(s.pendingDir, name))
+		if err != nil {
+			return nil, err
+		}
+		var p persistedSideTask
+		if err := json.Unmarshal(b, &p); err != nil {
+			return nil, err
+		}
+		tasks = append(tasks, sideTask{
+			id:         p.ID,
+			groupName:  p.GroupName,
+			attempts:   p.Attempts,
+			payload:    p.Payload,
+			payloadStr: p.PayloadStr,
+		})
+	}
+	return tasks, nil
+}
+
+func (as *AuditServer) replayDurablePending() {
+	if as.sideStore == nil {
+		return
+	}
+	tasks, err := as.sideStore.Pending()
+	if err != nil {
+		as.logger.Error("Failed to load durable pending tasks", "error", err)
+		return
+	}
+	for _, task := range tasks {
+		_ = as.enqueueSide(task)
+	}
+}

--- a/pkg/auditserver/server.go
+++ b/pkg/auditserver/server.go
@@ -225,6 +225,18 @@ func New(logger *slog.Logger) (*AuditServer, error) {
 	}
 
 	var ruleGroups []RuleGroup
+	if len(ruleGroupConfigs) == 0 {
+		defaultLogger := log.New(os.Stdout, "", 0)
+		ruleGroups = append(ruleGroups, RuleGroup{
+			Name:          "default",
+			CompiledRules: nil,
+			Logger:        defaultLogger,
+		})
+		return &AuditServer{
+			logger:     logger,
+			ruleGroups: ruleGroups,
+		}, nil
+	}
 	for _, rgConfig := range ruleGroupConfigs {
 		// Compile rules
 		var compiledRules []CompiledRule

--- a/pkg/auditserver/server.go
+++ b/pkg/auditserver/server.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/expr-lang/expr"
@@ -131,6 +132,8 @@ type AuditServer struct {
 	*gnet.EventServer
 	logger         *slog.Logger
 	ruleGroups     []RuleGroup
+	sideQueue      chan sideTask
+	sideDrops      atomic.Uint64
 	asyncQueueSize int
 	asyncTimeout   time.Duration
 }
@@ -147,9 +150,11 @@ func (as *AuditServer) React(frame []byte, c gnet.Conn) (out []byte, action gnet
 		return nil, gnet.Close
 	}
 
-	shouldClose := false
 	matched := false
-	forwarded := false
+	var payload []byte
+	var payloadStr string
+	payloadReady := false
+	payloadStrReady := false
 
 	// Check each rule group
 	for _, rg := range as.ruleGroups {
@@ -157,20 +162,21 @@ func (as *AuditServer) React(frame []byte, c gnet.Conn) (out []byte, action gnet
 			matched = true
 			as.logger.Debug("Matched rule group", "group", rg.Name)
 
-			// Send notification if messenger is configured
-			if rg.Messenger != nil {
-				if err := rg.Messenger.Send(string(frame)); err != nil {
-					as.logger.Error("Failed to send notification", "error", err)
-					shouldClose = true
+			if rg.Messenger != nil || rg.Forwarder != nil {
+				if !payloadReady {
+					payload = append([]byte(nil), frame...)
+					payloadReady = true
 				}
-			}
-
-			if rg.Forwarder != nil {
-				if err := rg.Forwarder.Forward(frame); err != nil {
-					as.logger.Error("Failed to forward message", "error", err)
-					shouldClose = true
+				if rg.Messenger != nil && !payloadStrReady {
+					payloadStr = string(payload)
+					payloadStrReady = true
 				}
-				forwarded = true
+				_ = as.enqueueSide(sideTask{
+					payload:    payload,
+					payloadStr: payloadStr,
+					messenger:  rg.Messenger,
+					forwarder:  rg.Forwarder,
+				})
 			}
 
 			// zero‑copy write to log when possible
@@ -179,7 +185,11 @@ func (as *AuditServer) React(frame []byte, c gnet.Conn) (out []byte, action gnet
 					as.logger.Error("Failed to write audit log", "group", rg.Name, "error", err)
 				}
 			} else {
-				rg.Logger.Print(string(frame))
+				if payloadStrReady {
+					rg.Logger.Print(payloadStr)
+				} else {
+					rg.Logger.Print(string(frame))
+				}
 			}
 			// TODO(JM):Add a flag to prevent logging to multiple groups
 			// break
@@ -188,11 +198,7 @@ func (as *AuditServer) React(frame []byte, c gnet.Conn) (out []byte, action gnet
 
 	auditLogPool.Put(auditLog)
 
-	// Preserve test expectations:
-	// - Close on any messenger/forwarder error
-	// - Close when no rule matched
-	// - Close when a message was forwarded (original behaviour)
-	if shouldClose || !matched || forwarded {
+	if !matched {
 		return nil, gnet.Close
 	}
 	return nil, gnet.None
@@ -248,14 +254,8 @@ func New(logger *slog.Logger) (*AuditServer, error) {
 			CompiledRules: nil,
 			Logger:        defaultLogger,
 		})
-		return &AuditServer{
-			logger:         logger,
-			ruleGroups:     ruleGroups,
-			asyncQueueSize: queueSize,
-			asyncTimeout:   asyncTimeout,
-		}, nil
-	}
-	for _, rgConfig := range ruleGroupConfigs {
+	} else {
+		for _, rgConfig := range ruleGroupConfigs {
 		// Compile rules
 		var compiledRules []CompiledRule
 		for _, ruleStr := range rgConfig.Rules {
@@ -311,11 +311,15 @@ func New(logger *slog.Logger) (*AuditServer, error) {
 			Forwarder:     fwd,
 		})
 	}
+	}
 
-	return &AuditServer{
+	server := &AuditServer{
 		logger:         logger,
 		ruleGroups:     ruleGroups,
+		sideQueue:      make(chan sideTask, queueSize),
 		asyncQueueSize: queueSize,
 		asyncTimeout:   asyncTimeout,
-	}, nil
+	}
+	server.startSideWorkers(defaultSideWorkers)
+	return server, nil
 }

--- a/pkg/auditserver/server.go
+++ b/pkg/auditserver/server.go
@@ -129,8 +129,10 @@ type LogFileConfig struct {
 
 type AuditServer struct {
 	*gnet.EventServer
-	logger     *slog.Logger
-	ruleGroups []RuleGroup
+	logger         *slog.Logger
+	ruleGroups     []RuleGroup
+	asyncQueueSize int
+	asyncTimeout   time.Duration
 }
 
 func (as *AuditServer) React(frame []byte, c gnet.Conn) (out []byte, action gnet.Action) {
@@ -217,6 +219,20 @@ func New(logger *slog.Logger) (*AuditServer, error) {
 		logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	}
 
+	viper.SetDefault("async.queue_size", 20)
+	viper.SetDefault("async.timeout", "5s")
+
+	queueSize := viper.GetInt("async.queue_size")
+	if queueSize <= 0 {
+		queueSize = 20
+	}
+	rawTimeout := viper.GetString("async.timeout")
+	asyncTimeout, err := time.ParseDuration(rawTimeout)
+	if err != nil {
+		asyncTimeout = 5 * time.Second
+		logger.Warn("Invalid async.timeout; using default", "value", rawTimeout)
+	}
+
 	// Load rule groups from configuration
 	var ruleGroupConfigs []RuleGroupConfig
 	if err := viper.UnmarshalKey("rule_groups", &ruleGroupConfigs); err != nil {
@@ -233,8 +249,10 @@ func New(logger *slog.Logger) (*AuditServer, error) {
 			Logger:        defaultLogger,
 		})
 		return &AuditServer{
-			logger:     logger,
-			ruleGroups: ruleGroups,
+			logger:         logger,
+			ruleGroups:     ruleGroups,
+			asyncQueueSize: queueSize,
+			asyncTimeout:   asyncTimeout,
 		}, nil
 	}
 	for _, rgConfig := range ruleGroupConfigs {
@@ -295,7 +313,9 @@ func New(logger *slog.Logger) (*AuditServer, error) {
 	}
 
 	return &AuditServer{
-		logger:     logger,
-		ruleGroups: ruleGroups,
+		logger:         logger,
+		ruleGroups:     ruleGroups,
+		asyncQueueSize: queueSize,
+		asyncTimeout:   asyncTimeout,
 	}, nil
 }

--- a/pkg/auditserver/server.go
+++ b/pkg/auditserver/server.go
@@ -300,6 +300,9 @@ func New(logger *slog.Logger) (*AuditServer, error) {
 				logger.Error("Failed to create UDP forwarder", "error", err)
 				return nil, fmt.Errorf("failed to create UDP forwarder: %w", err)
 			}
+			if udpFwd, ok := fwd.(*forwarder.UDPForwarder); ok {
+				udpFwd.SetTimeout(asyncTimeout)
+			}
 		}
 
 		ruleGroups = append(ruleGroups, RuleGroup{

--- a/pkg/auditserver/server.go
+++ b/pkg/auditserver/server.go
@@ -282,9 +282,9 @@ func New(logger *slog.Logger) (*AuditServer, error) {
 		var messenger messaging.Messenger
 		switch rgConfig.Messaging.Type {
 		case "slack":
-			messenger = messaging.NewSlackMessenger(rgConfig.Messaging.URL, rgConfig.Messaging.Token, rgConfig.Messaging.Channel)
+			messenger = messaging.NewSlackMessenger(rgConfig.Messaging.URL, rgConfig.Messaging.Token, rgConfig.Messaging.Channel, asyncTimeout)
 		case "slack_webhook":
-			messenger = messaging.NewSlackWebhookMessenger(rgConfig.Messaging.WebhookURL)
+			messenger = messaging.NewSlackWebhookMessenger(rgConfig.Messaging.WebhookURL, asyncTimeout)
 		default:
 			if rgConfig.Messaging.Type != "" {
 				logger.Error("Invalid messenger type", "type", rgConfig.Messaging.Type)

--- a/pkg/auditserver/server.go
+++ b/pkg/auditserver/server.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -130,12 +131,21 @@ type LogFileConfig struct {
 
 type AuditServer struct {
 	*gnet.EventServer
-	logger         *slog.Logger
-	ruleGroups     []RuleGroup
-	sideQueue      chan sideTask
-	sideDrops      atomic.Uint64
-	asyncQueueSize int
-	asyncTimeout   time.Duration
+	logger                *slog.Logger
+	ruleGroups            []RuleGroup
+	sideQueue             chan sideTask
+	sideDrops             atomic.Uint64
+	asyncEnqueueMode      string
+	asyncEnqueueTimeout   time.Duration
+	asyncWorkers          int
+	asyncQueueSize        int
+	asyncTimeout          time.Duration
+	asyncDurableEnabled   bool
+	asyncDurableDir       string
+	asyncRetryMaxAttempts int
+	asyncRetryBackoff     time.Duration
+	sideStore             sideTaskStore
+	sideTaskSeq           atomic.Uint64
 }
 
 func (as *AuditServer) React(frame []byte, c gnet.Conn) (out []byte, action gnet.Action) {
@@ -172,6 +182,7 @@ func (as *AuditServer) React(frame []byte, c gnet.Conn) (out []byte, action gnet
 					payloadStrReady = true
 				}
 				_ = as.enqueueSide(sideTask{
+					groupName:  rg.Name,
 					payload:    payload,
 					payloadStr: payloadStr,
 					messenger:  rg.Messenger,
@@ -226,17 +237,57 @@ func New(logger *slog.Logger) (*AuditServer, error) {
 	}
 
 	viper.SetDefault("async.queue_size", 20)
+	viper.SetDefault("async.workers", defaultSideWorkers)
+	viper.SetDefault("async.enqueue_mode", "drop")
+	viper.SetDefault("async.enqueue_timeout", "5ms")
 	viper.SetDefault("async.timeout", "5s")
+	viper.SetDefault("async.durable.enabled", false)
+	viper.SetDefault("async.durable.dir", "./.vault-audit-filter-sideeffects")
+	viper.SetDefault("async.retry.max_attempts", 3)
+	viper.SetDefault("async.retry.backoff", "100ms")
 
 	queueSize := viper.GetInt("async.queue_size")
 	if queueSize <= 0 {
 		queueSize = 20
+	}
+	workers := viper.GetInt("async.workers")
+	if workers < 0 {
+		workers = defaultSideWorkers
+	}
+	enqueueMode := strings.ToLower(strings.TrimSpace(viper.GetString("async.enqueue_mode")))
+	if enqueueMode == "" {
+		enqueueMode = "drop"
+	}
+	if enqueueMode != "drop" && enqueueMode != "wait" {
+		logger.Warn("Invalid async.enqueue_mode; using default", "value", enqueueMode)
+		enqueueMode = "drop"
+	}
+	rawEnqueueTimeout := viper.GetString("async.enqueue_timeout")
+	enqueueTimeout, err := time.ParseDuration(rawEnqueueTimeout)
+	if err != nil || enqueueTimeout <= 0 {
+		enqueueTimeout = 5 * time.Millisecond
+		logger.Warn("Invalid async.enqueue_timeout; using default", "value", rawEnqueueTimeout)
 	}
 	rawTimeout := viper.GetString("async.timeout")
 	asyncTimeout, err := time.ParseDuration(rawTimeout)
 	if err != nil {
 		asyncTimeout = 5 * time.Second
 		logger.Warn("Invalid async.timeout; using default", "value", rawTimeout)
+	}
+	durableEnabled := viper.GetBool("async.durable.enabled")
+	durableDir := strings.TrimSpace(viper.GetString("async.durable.dir"))
+	if durableDir == "" {
+		durableDir = "./.vault-audit-filter-sideeffects"
+	}
+	retryMaxAttempts := viper.GetInt("async.retry.max_attempts")
+	if retryMaxAttempts <= 0 {
+		retryMaxAttempts = 3
+	}
+	rawRetryBackoff := viper.GetString("async.retry.backoff")
+	retryBackoff, err := time.ParseDuration(rawRetryBackoff)
+	if err != nil || retryBackoff <= 0 {
+		retryBackoff = 100 * time.Millisecond
+		logger.Warn("Invalid async.retry.backoff; using default", "value", rawRetryBackoff)
 	}
 
 	// Load rule groups from configuration
@@ -256,73 +307,90 @@ func New(logger *slog.Logger) (*AuditServer, error) {
 		})
 	} else {
 		for _, rgConfig := range ruleGroupConfigs {
-		// Compile rules
-		var compiledRules []CompiledRule
-		for _, ruleStr := range rgConfig.Rules {
-			program, err := expr.Compile(ruleStr, expr.Env(&AuditLog{}))
-			if err != nil {
-				logger.Error("Failed to compile rule", "rule", ruleStr, "error", err)
-				continue
+			// Compile rules
+			var compiledRules []CompiledRule
+			for _, ruleStr := range rgConfig.Rules {
+				program, err := expr.Compile(ruleStr, expr.Env(&AuditLog{}))
+				if err != nil {
+					logger.Error("Failed to compile rule", "rule", ruleStr, "error", err)
+					continue
+				}
+				compiledRules = append(compiledRules, CompiledRule{Program: program})
 			}
-			compiledRules = append(compiledRules, CompiledRule{Program: program})
-		}
 
-		// Logger for group
-		logFileCfg := rgConfig.LogFile
-		logFile := &lumberjack.Logger{
-			Filename:   logFileCfg.FilePath,
-			MaxSize:    logFileCfg.MaxSize,
-			MaxBackups: logFileCfg.MaxBackups,
-			MaxAge:     logFileCfg.MaxAge,
-			Compress:   logFileCfg.Compress,
-		}
-		groupLogger := log.New(logFile, "", 0)
-
-		// Messenger
-		var messenger messaging.Messenger
-		switch rgConfig.Messaging.Type {
-		case "slack":
-			messenger = messaging.NewSlackMessenger(rgConfig.Messaging.URL, rgConfig.Messaging.Token, rgConfig.Messaging.Channel, asyncTimeout)
-		case "slack_webhook":
-			messenger = messaging.NewSlackWebhookMessenger(rgConfig.Messaging.WebhookURL, asyncTimeout)
-		default:
-			if rgConfig.Messaging.Type != "" {
-				logger.Error("Invalid messenger type", "type", rgConfig.Messaging.Type)
+			// Logger for group
+			logFileCfg := rgConfig.LogFile
+			logFile := &lumberjack.Logger{
+				Filename:   logFileCfg.FilePath,
+				MaxSize:    logFileCfg.MaxSize,
+				MaxBackups: logFileCfg.MaxBackups,
+				MaxAge:     logFileCfg.MaxAge,
+				Compress:   logFileCfg.Compress,
 			}
-		}
+			groupLogger := log.New(logFile, "", 0)
 
-		// Forwarder
-		var fwd forwarder.Forwarder
-		if rgConfig.Forwarding.Enabled {
-			var err error
-			fwd, err = forwarder.NewUDPForwarder(rgConfig.Forwarding.Address)
-			if err != nil {
-				logger.Error("Failed to create UDP forwarder", "error", err)
-				return nil, fmt.Errorf("failed to create UDP forwarder: %w", err)
+			// Messenger
+			var messenger messaging.Messenger
+			switch rgConfig.Messaging.Type {
+			case "slack":
+				messenger = messaging.NewSlackMessenger(rgConfig.Messaging.URL, rgConfig.Messaging.Token, rgConfig.Messaging.Channel, asyncTimeout)
+			case "slack_webhook":
+				messenger = messaging.NewSlackWebhookMessenger(rgConfig.Messaging.WebhookURL, asyncTimeout)
+			default:
+				if rgConfig.Messaging.Type != "" {
+					logger.Error("Invalid messenger type", "type", rgConfig.Messaging.Type)
+				}
 			}
-			if udpFwd, ok := fwd.(*forwarder.UDPForwarder); ok {
-				udpFwd.SetTimeout(asyncTimeout)
-			}
-		}
 
-		ruleGroups = append(ruleGroups, RuleGroup{
-			Name:          rgConfig.Name,
-			CompiledRules: compiledRules,
-			Logger:        groupLogger,
-			Writer:        logFile,
-			Messenger:     messenger,
-			Forwarder:     fwd,
-		})
-	}
+			// Forwarder
+			var fwd forwarder.Forwarder
+			if rgConfig.Forwarding.Enabled {
+				var err error
+				fwd, err = forwarder.NewUDPForwarder(rgConfig.Forwarding.Address)
+				if err != nil {
+					logger.Error("Failed to create UDP forwarder", "error", err)
+					return nil, fmt.Errorf("failed to create UDP forwarder: %w", err)
+				}
+				if udpFwd, ok := fwd.(*forwarder.UDPForwarder); ok {
+					udpFwd.SetTimeout(asyncTimeout)
+				}
+			}
+
+			ruleGroups = append(ruleGroups, RuleGroup{
+				Name:          rgConfig.Name,
+				CompiledRules: compiledRules,
+				Logger:        groupLogger,
+				Writer:        logFile,
+				Messenger:     messenger,
+				Forwarder:     fwd,
+			})
+		}
 	}
 
 	server := &AuditServer{
-		logger:         logger,
-		ruleGroups:     ruleGroups,
-		sideQueue:      make(chan sideTask, queueSize),
-		asyncQueueSize: queueSize,
-		asyncTimeout:   asyncTimeout,
+		logger:                logger,
+		ruleGroups:            ruleGroups,
+		sideQueue:             make(chan sideTask, queueSize),
+		asyncEnqueueMode:      enqueueMode,
+		asyncEnqueueTimeout:   enqueueTimeout,
+		asyncWorkers:          workers,
+		asyncQueueSize:        queueSize,
+		asyncTimeout:          asyncTimeout,
+		asyncDurableEnabled:   durableEnabled,
+		asyncDurableDir:       durableDir,
+		asyncRetryMaxAttempts: retryMaxAttempts,
+		asyncRetryBackoff:     retryBackoff,
 	}
-	server.startSideWorkers(defaultSideWorkers)
+	if durableEnabled {
+		store, err := newFileSideTaskStore(durableDir)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create durable side task store: %w", err)
+		}
+		server.sideStore = store
+	}
+	server.startSideWorkers(workers)
+	if durableEnabled {
+		server.replayDurablePending()
+	}
 	return server, nil
 }

--- a/pkg/auditserver/server_test.go
+++ b/pkg/auditserver/server_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -375,8 +376,22 @@ func TestNew_AsyncDefaults(t *testing.T) {
 	server, err := New(nil)
 	require.NoError(t, err)
 	require.NotNil(t, server)
+	assert.Equal(t, "drop", server.asyncEnqueueMode)
+	assert.Equal(t, 5*time.Millisecond, server.asyncEnqueueTimeout)
+	assert.Equal(t, 2, server.asyncWorkers)
 	assert.Equal(t, 20, server.asyncQueueSize)
 	assert.Equal(t, 5*time.Second, server.asyncTimeout)
+}
+
+func TestNew_InvalidEnqueueModeFallsBackToDrop(t *testing.T) {
+	viper.Reset()
+	viper.Set("async.enqueue_mode", "invalid")
+	viper.Set("async.enqueue_timeout", "12ms")
+
+	server, err := New(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "drop", server.asyncEnqueueMode)
+	assert.Equal(t, 12*time.Millisecond, server.asyncEnqueueTimeout)
 }
 
 func TestSideQueue_DropsWhenFull(t *testing.T) {
@@ -443,6 +458,234 @@ func TestReact_AsyncMessengerCalled(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatalf("messenger not called")
 	}
+}
+
+func TestNew_AsyncWorkersCanBeDisabled(t *testing.T) {
+	viper.Reset()
+	viper.Set("async.queue_size", 10)
+	viper.Set("async.workers", 0)
+	viper.Set("rule_groups", []map[string]interface{}{
+		{
+			"name":     "rg",
+			"rules":    []string{"true"},
+			"log_file": map[string]interface{}{"file_path": "/tmp/test.log", "max_size": 1},
+			"messaging": map[string]interface{}{
+				"type":        "slack_webhook",
+				"webhook_url": "http://example.com",
+			},
+		},
+	})
+
+	srv, err := New(nil)
+	require.NoError(t, err)
+
+	called := make(chan struct{}, 1)
+	for i := range srv.ruleGroups {
+		srv.ruleGroups[i].Messenger = &MockMessenger{SendFunc: func(string) error {
+			called <- struct{}{}
+			return nil
+		}}
+	}
+
+	frame := []byte(`{"type":"request","time":"2000-01-01T00:00:00Z","auth":{},"request":{},"response":{}}`)
+	_, action := srv.React(frame, nil)
+	assert.Equal(t, gnet.None, action)
+
+	select {
+	case <-called:
+		t.Fatalf("messenger should not be called when async.workers=0")
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func TestNew_AsyncWorkersCanOverrideDefault(t *testing.T) {
+	viper.Reset()
+	viper.Set("async.queue_size", 10)
+	viper.Set("async.workers", 1)
+	viper.Set("rule_groups", []map[string]interface{}{
+		{
+			"name":     "rg",
+			"rules":    []string{"true"},
+			"log_file": map[string]interface{}{"file_path": "/tmp/test.log", "max_size": 1},
+			"messaging": map[string]interface{}{
+				"type":        "slack_webhook",
+				"webhook_url": "http://example.com",
+			},
+		},
+	})
+
+	oldWorkers := defaultSideWorkers
+	defaultSideWorkers = 0
+	defer func() { defaultSideWorkers = oldWorkers }()
+
+	srv, err := New(nil)
+	require.NoError(t, err)
+
+	called := make(chan struct{}, 1)
+	for i := range srv.ruleGroups {
+		srv.ruleGroups[i].Messenger = &MockMessenger{SendFunc: func(string) error {
+			called <- struct{}{}
+			return nil
+		}}
+	}
+
+	frame := []byte(`{"type":"request","time":"2000-01-01T00:00:00Z","auth":{},"request":{},"response":{}}`)
+	_, action := srv.React(frame, nil)
+	assert.Equal(t, gnet.None, action)
+
+	select {
+	case <-called:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("messenger should be called when async.workers=1")
+	}
+}
+
+func TestEnqueueSide_DropMode_DropsImmediatelyWhenFull(t *testing.T) {
+	as := &AuditServer{
+		sideQueue: make(chan sideTask, 1),
+	}
+	as.sideQueue <- sideTask{}
+
+	start := time.Now()
+	ok := as.enqueueSide(sideTask{})
+	elapsed := time.Since(start)
+
+	assert.False(t, ok)
+	assert.Equal(t, uint64(1), as.sideDrops.Load())
+	assert.Less(t, elapsed, 10*time.Millisecond)
+}
+
+func TestEnqueueSide_WaitMode_TimesOutWhenFull(t *testing.T) {
+	as := &AuditServer{
+		sideQueue:           make(chan sideTask, 1),
+		asyncEnqueueMode:    "wait",
+		asyncEnqueueTimeout: 30 * time.Millisecond,
+	}
+	as.sideQueue <- sideTask{}
+
+	start := time.Now()
+	ok := as.enqueueSide(sideTask{})
+	elapsed := time.Since(start)
+
+	assert.False(t, ok)
+	assert.Equal(t, uint64(1), as.sideDrops.Load())
+	assert.GreaterOrEqual(t, elapsed, 25*time.Millisecond)
+}
+
+func TestEnqueueSide_WaitMode_EnqueuesWhenCapacityFrees(t *testing.T) {
+	as := &AuditServer{
+		sideQueue:           make(chan sideTask, 1),
+		asyncEnqueueMode:    "wait",
+		asyncEnqueueTimeout: 200 * time.Millisecond,
+	}
+	as.sideQueue <- sideTask{}
+
+	go func() {
+		time.Sleep(25 * time.Millisecond)
+		<-as.sideQueue
+	}()
+
+	start := time.Now()
+	ok := as.enqueueSide(sideTask{})
+	elapsed := time.Since(start)
+
+	assert.True(t, ok)
+	assert.Equal(t, uint64(0), as.sideDrops.Load())
+	assert.GreaterOrEqual(t, elapsed, 20*time.Millisecond)
+	assert.Less(t, elapsed, 200*time.Millisecond)
+}
+
+func TestEnqueueSide_DurableMode_PersistsWhenQueueFull(t *testing.T) {
+	store, err := newFileSideTaskStore(t.TempDir())
+	require.NoError(t, err)
+
+	as := &AuditServer{
+		logger:              slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		sideQueue:           make(chan sideTask, 1),
+		asyncDurableEnabled: true,
+		asyncRetryBackoff:   20 * time.Millisecond,
+		sideStore:           store,
+	}
+	as.sideQueue <- sideTask{}
+
+	ok := as.enqueueSide(sideTask{groupName: "g", payload: []byte("x"), payloadStr: "x"})
+	require.True(t, ok)
+	assert.Equal(t, uint64(0), as.sideDrops.Load())
+
+	tasks, err := as.sideStore.Pending()
+	require.NoError(t, err)
+	require.Len(t, tasks, 1)
+}
+
+func TestProcessSideTask_DurableRetryToDeadLetter(t *testing.T) {
+	store, err := newFileSideTaskStore(t.TempDir())
+	require.NoError(t, err)
+
+	as := &AuditServer{
+		logger:                slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		sideQueue:             make(chan sideTask, 8),
+		asyncDurableEnabled:   true,
+		asyncRetryMaxAttempts: 2,
+		asyncRetryBackoff:     20 * time.Millisecond,
+		sideStore:             store,
+	}
+	as.startSideWorkers(1)
+
+	task := sideTask{
+		id:         "task-1",
+		groupName:  "g",
+		payload:    []byte("x"),
+		payloadStr: "x",
+		messenger:  &dummyMessenger{sendErr: errors.New("boom")},
+	}
+	require.NoError(t, as.sideStore.Save(task))
+
+	as.processSideTask(task)
+
+	require.Eventually(t, func() bool {
+		pending, err := as.sideStore.Pending()
+		if err != nil {
+			return false
+		}
+		if len(pending) != 0 {
+			return false
+		}
+		_, err = os.Stat(filepath.Join(store.deadDir, "task-1.json"))
+		return err == nil
+	}, 2*time.Second, 25*time.Millisecond)
+}
+
+func TestReplayDurablePending_ReplaysStoredTasks(t *testing.T) {
+	store, err := newFileSideTaskStore(t.TempDir())
+	require.NoError(t, err)
+
+	msg := &dummyMessenger{}
+	as := &AuditServer{
+		logger:                slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		sideQueue:             make(chan sideTask, 8),
+		asyncDurableEnabled:   true,
+		asyncRetryMaxAttempts: 2,
+		asyncRetryBackoff:     10 * time.Millisecond,
+		sideStore:             store,
+		ruleGroups: []RuleGroup{{
+			Name:      "g",
+			Messenger: msg,
+		}},
+	}
+	as.startSideWorkers(1)
+
+	require.NoError(t, as.sideStore.Save(sideTask{id: "task-a", groupName: "g", payload: []byte("a"), payloadStr: "a"}))
+	require.NoError(t, as.sideStore.Save(sideTask{id: "task-b", groupName: "g", payload: []byte("b"), payloadStr: "b"}))
+
+	as.replayDurablePending()
+
+	require.Eventually(t, func() bool {
+		return msg.Calls() == 2
+	}, 2*time.Second, 25*time.Millisecond)
+
+	pending, err := as.sideStore.Pending()
+	require.NoError(t, err)
+	assert.Len(t, pending, 0)
 }
 
 func TestNewWithoutLogger(t *testing.T) {
@@ -1057,9 +1300,9 @@ func TestReact_Branches(t *testing.T) {
 		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			srv := &AuditServer{
-				logger:    logger,
+				logger:     logger,
 				ruleGroups: []RuleGroup{tc.group},
-				sideQueue: make(chan sideTask, 2),
+				sideQueue:  make(chan sideTask, 2),
 			}
 			srv.startSideWorkers(1)
 

--- a/pkg/auditserver/server_test.go
+++ b/pkg/auditserver/server_test.go
@@ -1022,18 +1022,28 @@ func TestReact_Branches(t *testing.T) {
 		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			srv := &AuditServer{
-				logger:     logger,
+				logger:    logger,
 				ruleGroups: []RuleGroup{tc.group},
+				sideQueue: make(chan sideTask, 2),
 			}
+			srv.startSideWorkers(1)
 
 			_, act := srv.React(frame, nil)
 			require.Equal(t, tc.wantAction, act)
 
 			if dm, ok := tc.group.Messenger.(*dummyMessenger); ok {
-				require.Equal(t, tc.wantMsgCalls, dm.calls)
+				if tc.wantMsgCalls > 0 {
+					require.Eventually(t, func() bool { return dm.calls == tc.wantMsgCalls }, time.Second, 10*time.Millisecond)
+				} else {
+					require.Equal(t, tc.wantMsgCalls, dm.calls)
+				}
 			}
 			if df, ok := tc.group.Forwarder.(*dummyForwarder); ok {
-				require.Equal(t, tc.wantFwdCalls, df.calls)
+				if tc.wantFwdCalls > 0 {
+					require.Eventually(t, func() bool { return df.calls == tc.wantFwdCalls }, time.Second, 10*time.Millisecond)
+				} else {
+					require.Equal(t, tc.wantFwdCalls, df.calls)
+				}
 			}
 		})
 	}

--- a/pkg/auditserver/server_test.go
+++ b/pkg/auditserver/server_test.go
@@ -334,6 +334,25 @@ func TestNew(t *testing.T) {
 	}
 }
 
+func TestNew_DefaultRuleGroup_WhenMissingOrEmpty(t *testing.T) {
+	viper.Reset()
+
+	// Missing rule_groups
+	server, err := New(nil)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	require.Len(t, server.ruleGroups, 1)
+	assert.Len(t, server.ruleGroups[0].CompiledRules, 0)
+	assert.NotNil(t, server.ruleGroups[0].Logger)
+
+	// Empty rule_groups
+	viper.Reset()
+	viper.Set("rule_groups", []map[string]interface{}{})
+	server, err = New(nil)
+	require.NoError(t, err)
+	require.Len(t, server.ruleGroups, 1)
+}
+
 func TestNewWithoutLogger(t *testing.T) {
 	// Redirect stdout to capture log output
 	oldStdout := os.Stdout

--- a/pkg/auditserver/server_test.go
+++ b/pkg/auditserver/server_test.go
@@ -1326,3 +1326,167 @@ func TestReact_Branches(t *testing.T) {
 		})
 	}
 }
+
+type errSideTaskStore struct {
+	mu          sync.Mutex
+	saveErr     error
+	deleteErr   error
+	deadErr     error
+	pendingErr  error
+	pending     []sideTask
+	saveCalls   int
+	deleteCalls int
+	deadCalls   int
+}
+
+func (s *errSideTaskStore) Save(task sideTask) error {
+	s.mu.Lock()
+	s.saveCalls++
+	if s.saveErr == nil {
+		s.pending = append(s.pending, task)
+	}
+	s.mu.Unlock()
+	return s.saveErr
+}
+
+func (s *errSideTaskStore) Delete(id string) error {
+	s.mu.Lock()
+	s.deleteCalls++
+	if s.deleteErr == nil && id != "" {
+		filtered := s.pending[:0]
+		for _, task := range s.pending {
+			if task.id != id {
+				filtered = append(filtered, task)
+			}
+		}
+		s.pending = filtered
+	}
+	s.mu.Unlock()
+	return s.deleteErr
+}
+
+func (s *errSideTaskStore) MoveToDeadLetter(task sideTask, reason string) error {
+	s.mu.Lock()
+	s.deadCalls++
+	s.mu.Unlock()
+	_ = task
+	_ = reason
+	return s.deadErr
+}
+
+func (s *errSideTaskStore) Pending() ([]sideTask, error) {
+	if s.pendingErr != nil {
+		return nil, s.pendingErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]sideTask, len(s.pending))
+	copy(out, s.pending)
+	return out, nil
+}
+
+func TestNew_AsyncInvalidConfigFallsBackToDefaults(t *testing.T) {
+	viper.Reset()
+	viper.Set("rule_groups", []map[string]interface{}{})
+	viper.Set("async.queue_size", 0)
+	viper.Set("async.workers", -3)
+	viper.Set("async.enqueue_mode", "invalid")
+	viper.Set("async.enqueue_timeout", "not-a-duration")
+	viper.Set("async.timeout", "also-bad")
+	viper.Set("async.durable.enabled", false)
+	viper.Set("async.durable.dir", "")
+	viper.Set("async.retry.max_attempts", 0)
+	viper.Set("async.retry.backoff", "bad")
+
+	server, err := New(nil)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	assert.Equal(t, 20, server.asyncQueueSize)
+	assert.Equal(t, defaultSideWorkers, server.asyncWorkers)
+	assert.Equal(t, "drop", server.asyncEnqueueMode)
+	assert.Equal(t, 5*time.Millisecond, server.asyncEnqueueTimeout)
+	assert.Equal(t, 5*time.Second, server.asyncTimeout)
+	assert.Equal(t, "./.vault-audit-filter-sideeffects", server.asyncDurableDir)
+	assert.Equal(t, 3, server.asyncRetryMaxAttempts)
+	assert.Equal(t, 100*time.Millisecond, server.asyncRetryBackoff)
+}
+
+func TestEnqueueSide_DurableSaveFailureReturnsFalse(t *testing.T) {
+	store := &errSideTaskStore{saveErr: errors.New("save failed")}
+	as := &AuditServer{
+		logger:              slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		sideQueue:           make(chan sideTask, 1),
+		asyncDurableEnabled: true,
+		sideStore:           store,
+	}
+
+	ok := as.enqueueSide(sideTask{id: "task-1"})
+	assert.False(t, ok)
+	assert.Equal(t, uint64(0), as.sideDrops.Load())
+}
+
+func TestEnqueueSide_WaitMode_DurableTimeoutReturnsTrue(t *testing.T) {
+	store := &errSideTaskStore{}
+	as := &AuditServer{
+		logger:              slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		sideQueue:           make(chan sideTask, 1),
+		asyncEnqueueMode:    "wait",
+		asyncEnqueueTimeout: 2 * time.Millisecond,
+		asyncDurableEnabled: true,
+		asyncRetryBackoff:   1 * time.Millisecond,
+		sideStore:           store,
+	}
+	as.sideQueue <- sideTask{id: "occupied"}
+
+	ok := as.enqueueSide(sideTask{id: "task-2"})
+	assert.True(t, ok)
+	assert.Equal(t, uint64(0), as.sideDrops.Load())
+}
+
+func TestFileSideTaskStore_Branches(t *testing.T) {
+	t.Run("new_store_errors", func(t *testing.T) {
+		baseDir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(baseDir, "deadletter"), []byte("x"), 0o600))
+		_, err := newFileSideTaskStore(baseDir)
+		require.Error(t, err)
+
+		fileBase := filepath.Join(t.TempDir(), "base-file")
+		require.NoError(t, os.WriteFile(fileBase, []byte("x"), 0o600))
+		_, err = newFileSideTaskStore(fileBase)
+		require.Error(t, err)
+	})
+
+	t.Run("save_delete_move_pending_edge_cases", func(t *testing.T) {
+		store, err := newFileSideTaskStore(t.TempDir())
+		require.NoError(t, err)
+
+		assert.Error(t, store.Save(sideTask{}))
+		assert.NoError(t, store.Delete(""))
+		assert.NoError(t, store.Delete("missing"))
+		assert.NoError(t, store.MoveToDeadLetter(sideTask{}, "ignored"))
+
+		badFile := filepath.Join(store.pendingDir, "broken.json")
+		require.NoError(t, os.WriteFile(badFile, []byte("{"), 0o600))
+		_, err = store.Pending()
+		require.Error(t, err)
+
+		store.pendingDir = filepath.Join(t.TempDir(), "pending-file")
+		require.NoError(t, os.WriteFile(store.pendingDir, []byte("x"), 0o600))
+		err = store.Delete("id-1")
+		require.Error(t, err)
+	})
+}
+
+func TestReplayDurablePending_NoStoreOrPendingError(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	asNoStore := &AuditServer{logger: logger}
+	asNoStore.replayDurablePending()
+
+	asErr := &AuditServer{
+		logger:    logger,
+		sideQueue: make(chan sideTask, 1),
+		sideStore: &errSideTaskStore{pendingErr: errors.New("boom")},
+	}
+	asErr.replayDurablePending()
+}

--- a/pkg/auditserver/server_test.go
+++ b/pkg/auditserver/server_test.go
@@ -353,6 +353,15 @@ func TestNew_DefaultRuleGroup_WhenMissingOrEmpty(t *testing.T) {
 	require.Len(t, server.ruleGroups, 1)
 }
 
+func TestNew_AsyncDefaults(t *testing.T) {
+	viper.Reset()
+	server, err := New(nil)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	assert.Equal(t, 20, server.asyncQueueSize)
+	assert.Equal(t, 5*time.Second, server.asyncTimeout)
+}
+
 func TestNewWithoutLogger(t *testing.T) {
 	// Redirect stdout to capture log output
 	oldStdout := os.Stdout

--- a/pkg/auditserver/server_test.go
+++ b/pkg/auditserver/server_test.go
@@ -160,7 +160,7 @@ func TestAuditServer_React(t *testing.T) {
 			expectedLogs: map[string]bool{
 				tempDir + "/normal_operations.log": true,
 			},
-			expectAction:   gnet.Close,
+			expectAction:   gnet.None,
 			messengerError: fmt.Errorf("failed to send message"),
 			expectedLogMessages: []string{
 				"Failed to send notification",
@@ -389,6 +389,43 @@ func TestSideQueue_DropsWhenFull(t *testing.T) {
 	_, _ = srv.React(frame, nil)
 
 	assert.Equal(t, uint64(1), srv.sideDrops.Load())
+}
+
+func TestReact_AsyncMessengerCalled(t *testing.T) {
+	viper.Reset()
+	viper.Set("async.queue_size", 10)
+	viper.Set("rule_groups", []map[string]interface{}{
+		{
+			"name":     "rg",
+			"rules":    []string{"true"},
+			"log_file": map[string]interface{}{"file_path": "/tmp/test.log", "max_size": 1},
+			"messaging": map[string]interface{}{
+				"type":        "slack_webhook",
+				"webhook_url": "http://example.com",
+			},
+		},
+	})
+
+	srv, err := New(nil)
+	require.NoError(t, err)
+
+	called := make(chan struct{}, 1)
+	for i := range srv.ruleGroups {
+		srv.ruleGroups[i].Messenger = &MockMessenger{SendFunc: func(string) error {
+			called <- struct{}{}
+			return nil
+		}}
+	}
+
+	frame := []byte(`{"type":"request","time":"2000-01-01T00:00:00Z","auth":{},"request":{},"response":{}}`)
+	_, action := srv.React(frame, nil)
+	assert.Equal(t, gnet.None, action)
+
+	select {
+	case <-called:
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("messenger not called")
+	}
 }
 
 func TestNewWithoutLogger(t *testing.T) {
@@ -752,7 +789,7 @@ func TestAuditServer_React_WithForwarding(t *testing.T) {
 				tempDir + "/normal_operations.log": true,
 				tempDir + "/critical_events.log":   false,
 			},
-			expectAction:      gnet.Close,
+			expectAction:      gnet.None,
 			expectedForwarded: true,
 			expectedForwarder: 0,
 		},
@@ -781,7 +818,7 @@ func TestAuditServer_React_WithForwarding(t *testing.T) {
 				tempDir + "/normal_operations.log": false,
 				tempDir + "/critical_events.log":   true,
 			},
-			expectAction:      gnet.Close,
+			expectAction:      gnet.None,
 			expectedForwarded: true,
 			expectedForwarder: 1,
 		},
@@ -943,7 +980,7 @@ func TestReact_Branches(t *testing.T) {
 				Writer:        new(bytes.Buffer),
 				Forwarder:     &dummyForwarder{},
 			},
-			wantAction:   gnet.Close,
+			wantAction:   gnet.None,
 			wantFwdCalls: 1,
 		},
 		{
@@ -954,7 +991,7 @@ func TestReact_Branches(t *testing.T) {
 				Writer:        new(bytes.Buffer),
 				Forwarder:     &dummyForwarder{forwardErr: errors.New("boom")},
 			},
-			wantAction:   gnet.Close,
+			wantAction:   gnet.None,
 			wantFwdCalls: 1,
 		},
 		{
@@ -965,7 +1002,7 @@ func TestReact_Branches(t *testing.T) {
 				Writer:        new(bytes.Buffer),
 				Messenger:     &dummyMessenger{sendErr: errors.New("boom")},
 			},
-			wantAction:   gnet.Close,
+			wantAction:   gnet.None,
 			wantMsgCalls: 1,
 		},
 		{

--- a/pkg/auditserver/server_test.go
+++ b/pkg/auditserver/server_test.go
@@ -362,6 +362,35 @@ func TestNew_AsyncDefaults(t *testing.T) {
 	assert.Equal(t, 5*time.Second, server.asyncTimeout)
 }
 
+func TestSideQueue_DropsWhenFull(t *testing.T) {
+	viper.Reset()
+	viper.Set("async.queue_size", 1)
+	oldWorkers := defaultSideWorkers
+	defaultSideWorkers = 0
+	defer func() { defaultSideWorkers = oldWorkers }()
+
+	viper.Set("rule_groups", []map[string]interface{}{
+		{
+			"name":     "rg",
+			"rules":    []string{"true"},
+			"log_file": map[string]interface{}{"file_path": "/tmp/test.log", "max_size": 1},
+			"messaging": map[string]interface{}{
+				"type":        "slack_webhook",
+				"webhook_url": "http://example.com",
+			},
+		},
+	})
+
+	srv, err := New(nil)
+	require.NoError(t, err)
+
+	frame := []byte(`{"type":"request","time":"2000-01-01T00:00:00Z","auth":{},"request":{},"response":{}}`)
+	_, _ = srv.React(frame, nil)
+	_, _ = srv.React(frame, nil)
+
+	assert.Equal(t, uint64(1), srv.sideDrops.Load())
+}
+
 func TestNewWithoutLogger(t *testing.T) {
 	// Redirect stdout to capture log output
 	oldStdout := os.Stdout

--- a/pkg/auditserver/server_test.go
+++ b/pkg/auditserver/server_test.go
@@ -1183,6 +1183,12 @@ type dummyForwarder struct {
 	calls      int
 }
 
+type errWriter struct{}
+
+func (e errWriter) Write(_ []byte) (int, error) {
+	return 0, errors.New("write failed")
+}
+
 func (d *dummyForwarder) Forward(_ []byte) error {
 	d.mu.Lock()
 	d.calls++
@@ -1325,6 +1331,196 @@ func TestReact_Branches(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestReact_WriteErrorAndLoggerPayloadBranches(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	frame := auditFrame()
+
+	t.Run("writer error branch", func(t *testing.T) {
+		srv := &AuditServer{
+			logger: logger,
+			ruleGroups: []RuleGroup{{
+				Name:          "werr",
+				CompiledRules: nil,
+				Writer:        errWriter{},
+			}},
+			sideQueue: make(chan sideTask, 1),
+		}
+		_, action := srv.React(frame, nil)
+		require.Equal(t, gnet.None, action)
+	})
+
+	t.Run("logger payloadStr branch", func(t *testing.T) {
+		msg := &dummyMessenger{}
+		buf := new(bytes.Buffer)
+		srv := &AuditServer{
+			logger: logger,
+			ruleGroups: []RuleGroup{{
+				Name:          "msg",
+				CompiledRules: nil,
+				Logger:        log.New(buf, "", 0),
+				Writer:        nil,
+				Messenger:     msg,
+			}},
+			sideQueue: make(chan sideTask, 1),
+		}
+		srv.startSideWorkers(1)
+
+		_, action := srv.React(frame, nil)
+		require.Equal(t, gnet.None, action)
+		require.Eventually(t, func() bool { return msg.Calls() == 1 }, time.Second, 10*time.Millisecond)
+		require.Contains(t, buf.String(), string(frame))
+	})
+}
+
+func TestRuleGroup_shouldLog_RuntimeErrorContinues(t *testing.T) {
+	good, err := expr.Compile(`true`, expr.Env(&AuditLog{}))
+	require.NoError(t, err)
+
+	rg := &RuleGroup{CompiledRules: []CompiledRule{{Program: nil}, {Program: good}}}
+	assert.True(t, rg.shouldLog(&AuditLog{}))
+}
+
+func TestNew_AsyncEnqueueModeBlankFallsBackToDrop(t *testing.T) {
+	viper.Reset()
+	viper.Set("rule_groups", []map[string]interface{}{})
+	viper.Set("async.enqueue_mode", "   ")
+
+	server, err := New(nil)
+	require.NoError(t, err)
+	assert.Equal(t, "drop", server.asyncEnqueueMode)
+}
+
+func TestNew_WithSlackMessengerAndDurableEnabled(t *testing.T) {
+	viper.Reset()
+	viper.Set("async.durable.enabled", true)
+	viper.Set("async.durable.dir", t.TempDir())
+	viper.Set("async.timeout", "17ms")
+	viper.Set("rule_groups", []map[string]interface{}{
+		{
+			"name": "slack_group",
+			"rules": []string{
+				"true",
+			},
+			"log_file": map[string]interface{}{
+				"file_path": filepath.Join(t.TempDir(), "slack.log"),
+				"max_size":  1,
+			},
+			"messaging": map[string]interface{}{
+				"type":    "slack",
+				"url":     "https://example.invalid",
+				"token":   "tok",
+				"channel": "chan",
+			},
+		},
+	})
+
+	server, err := New(nil)
+	require.NoError(t, err)
+	require.NotNil(t, server.sideStore)
+	require.True(t, server.asyncDurableEnabled)
+	require.Len(t, server.ruleGroups, 1)
+	require.NotNil(t, server.ruleGroups[0].Messenger)
+}
+
+func TestNew_DurableStoreCreationFailure(t *testing.T) {
+	viper.Reset()
+	viper.Set("async.durable.enabled", true)
+	badBase := filepath.Join(t.TempDir(), "base-file")
+	require.NoError(t, os.WriteFile(badBase, []byte("x"), 0o600))
+	viper.Set("async.durable.dir", badBase)
+	viper.Set("rule_groups", []map[string]interface{}{})
+
+	server, err := New(nil)
+	require.Error(t, err)
+	assert.Nil(t, server)
+	assert.Contains(t, err.Error(), "failed to create durable side task store")
+}
+
+func TestEnqueueSide_WaitMode_DefaultTimeoutBranch(t *testing.T) {
+	as := &AuditServer{
+		sideQueue:           make(chan sideTask, 1),
+		asyncEnqueueMode:    "wait",
+		asyncEnqueueTimeout: 0,
+	}
+	as.sideQueue <- sideTask{}
+
+	start := time.Now()
+	ok := as.enqueueSide(sideTask{})
+	elapsed := time.Since(start)
+
+	assert.False(t, ok)
+	assert.GreaterOrEqual(t, elapsed, 4*time.Millisecond)
+	assert.Equal(t, uint64(1), as.sideDrops.Load())
+}
+
+func TestProcessSideTask_RetrySaveErrorBranch(t *testing.T) {
+	store := &errSideTaskStore{saveErr: errors.New("save failed")}
+	as := &AuditServer{
+		logger:                slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		sideQueue:             make(chan sideTask, 1),
+		asyncDurableEnabled:   true,
+		asyncRetryMaxAttempts: 3,
+		asyncRetryBackoff:     10 * time.Millisecond,
+		sideStore:             store,
+	}
+
+	as.processSideTask(sideTask{
+		id:         "task-r1",
+		groupName:  "g",
+		payload:    []byte("x"),
+		payloadStr: "x",
+		messenger:  &dummyMessenger{sendErr: errors.New("send failed")},
+	})
+}
+
+func TestFileSideTaskStore_PendingReadDirAndReadFileBranches(t *testing.T) {
+	store, err := newFileSideTaskStore(t.TempDir())
+	require.NoError(t, err)
+
+	// cover entries that are directories (continue branch)
+	require.NoError(t, os.Mkdir(filepath.Join(store.pendingDir, "nested"), 0o755))
+	_, err = store.Pending()
+	require.NoError(t, err)
+
+	// cover os.ReadFile error branch using broken symlink
+	symlink := filepath.Join(store.pendingDir, "broken-link.json")
+	require.NoError(t, os.Symlink(filepath.Join(store.pendingDir, "does-not-exist.json"), symlink))
+	_, err = store.Pending()
+	require.Error(t, err)
+
+	// cover os.ReadDir error branch
+	store.pendingDir = filepath.Join(t.TempDir(), "not-a-dir")
+	require.NoError(t, os.WriteFile(store.pendingDir, []byte("x"), 0o600))
+	_, err = store.Pending()
+	require.Error(t, err)
+}
+
+func TestFileSideTaskStore_SaveAndMoveToDeadLetter_MarshalErrorBranches(t *testing.T) {
+	store, err := newFileSideTaskStore(t.TempDir())
+	require.NoError(t, err)
+
+	origPersist := marshalPersistedSideTask
+	origDead := marshalDeadLetterTask
+	t.Cleanup(func() {
+		marshalPersistedSideTask = origPersist
+		marshalDeadLetterTask = origDead
+	})
+
+	marshalPersistedSideTask = func(p persistedSideTask) ([]byte, error) {
+		_ = p
+		return nil, errors.New("marshal persisted failed")
+	}
+	err = store.Save(sideTask{id: "save-1"})
+	require.Error(t, err)
+
+	marshalDeadLetterTask = func(d deadLetterTask) ([]byte, error) {
+		_ = d
+		return nil, errors.New("marshal dead failed")
+	}
+	err = store.MoveToDeadLetter(sideTask{id: "dead-1"}, "reason")
+	require.Error(t, err)
 }
 
 type errSideTaskStore struct {

--- a/pkg/auditserver/server_test.go
+++ b/pkg/auditserver/server_test.go
@@ -60,6 +60,23 @@ func (m *MockMessenger) Send(message string) error {
 	return nil
 }
 
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
 // mockConn is a mock implementation of gnet.Conn
 type mockConn struct{}
 
@@ -210,8 +227,8 @@ func TestAuditServer_React(t *testing.T) {
 			}
 
 			// Capture logs
-			var logBuffer bytes.Buffer
-			logger := slog.New(slog.NewJSONHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			logBuffer := &lockedBuffer{}
+			logger := slog.New(slog.NewJSONHandler(logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 			// Create the AuditServer
 			as, _ := New(logger)
@@ -303,8 +320,8 @@ func TestNew(t *testing.T) {
 	viper.Set("rule_groups", ruleGroupConfigs)
 
 	// Capture logs
-	var logBuffer bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	logBuffer := &lockedBuffer{}
+	logger := slog.New(slog.NewJSONHandler(logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 	server, _ := New(logger)
 	if len(server.ruleGroups) != len(ruleGroupConfigs) {
@@ -900,22 +917,40 @@ func TestAuditServer_React_WithForwarding(t *testing.T) {
 
 type dummyMessenger struct {
 	sendErr error
+	mu      sync.Mutex
 	calls   int
 }
 
 func (d *dummyMessenger) Send(_ string) error {
+	d.mu.Lock()
 	d.calls++
+	d.mu.Unlock()
 	return d.sendErr
+}
+
+func (d *dummyMessenger) Calls() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.calls
 }
 
 type dummyForwarder struct {
 	forwardErr error
+	mu         sync.Mutex
 	calls      int
 }
 
 func (d *dummyForwarder) Forward(_ []byte) error {
+	d.mu.Lock()
 	d.calls++
+	d.mu.Unlock()
 	return d.forwardErr
+}
+
+func (d *dummyForwarder) Calls() int {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.calls
 }
 
 // minimal JSON frame that parses into an AuditLog
@@ -1033,16 +1068,16 @@ func TestReact_Branches(t *testing.T) {
 
 			if dm, ok := tc.group.Messenger.(*dummyMessenger); ok {
 				if tc.wantMsgCalls > 0 {
-					require.Eventually(t, func() bool { return dm.calls == tc.wantMsgCalls }, time.Second, 10*time.Millisecond)
+					require.Eventually(t, func() bool { return dm.Calls() == tc.wantMsgCalls }, time.Second, 10*time.Millisecond)
 				} else {
-					require.Equal(t, tc.wantMsgCalls, dm.calls)
+					require.Equal(t, tc.wantMsgCalls, dm.Calls())
 				}
 			}
 			if df, ok := tc.group.Forwarder.(*dummyForwarder); ok {
 				if tc.wantFwdCalls > 0 {
-					require.Eventually(t, func() bool { return df.calls == tc.wantFwdCalls }, time.Second, 10*time.Millisecond)
+					require.Eventually(t, func() bool { return df.Calls() == tc.wantFwdCalls }, time.Second, 10*time.Millisecond)
 				} else {
-					require.Equal(t, tc.wantFwdCalls, df.calls)
+					require.Equal(t, tc.wantFwdCalls, df.Calls())
 				}
 			}
 		})

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -1,7 +1,10 @@
 package forwarder
 
 import (
+	"errors"
 	"net"
+	"sync"
+	"time"
 )
 
 // Forwarder is an interface for forwarding messages
@@ -11,7 +14,9 @@ type Forwarder interface {
 
 // UDPForwarder implements the Forwarder interface for UDP
 type UDPForwarder struct {
-	conn *net.UDPConn
+	conn    *net.UDPConn
+	timeout time.Duration
+	mu      sync.Mutex
 }
 
 // NewUDPForwarder creates a new UDPForwarder
@@ -27,8 +32,21 @@ func NewUDPForwarder(address string) (*UDPForwarder, error) {
 	return &UDPForwarder{conn: conn}, nil
 }
 
+// SetTimeout configures a per-write deadline for UDP forwarding.
+func (f *UDPForwarder) SetTimeout(timeout time.Duration) {
+	f.timeout = timeout
+}
+
 // Forward sends the data to the UDP address
 func (f *UDPForwarder) Forward(data []byte) error {
+	if f.conn == nil {
+		return errors.New("udp connection is nil")
+	}
+	if f.timeout > 0 {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+		_ = f.conn.SetWriteDeadline(time.Now().Add(f.timeout))
+	}
 	_, err := f.conn.Write(data)
 	return err
 }

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUDPForwarder(t *testing.T) {
@@ -122,6 +123,21 @@ func TestUDPForwarder_ForwardToUnreachableAddress(t *testing.T) {
 
 	// This should not return an error for UDP, as it's connectionless
 	assert.NoError(t, err)
+}
+
+func TestUDPForwarder_SetTimeout(t *testing.T) {
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	conn, err := net.ListenUDP("udp", addr)
+	require.NoError(t, err)
+	defer conn.Close()
+
+	forwarder, err := NewUDPForwarder(conn.LocalAddr().String())
+	require.NoError(t, err)
+
+	forwarder.SetTimeout(10 * time.Millisecond)
+	assert.NoError(t, forwarder.Forward([]byte("msg")))
 }
 
 func TestUDPForwarder_ConcurrentForwarding(t *testing.T) {

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -140,6 +140,13 @@ func TestUDPForwarder_SetTimeout(t *testing.T) {
 	assert.NoError(t, forwarder.Forward([]byte("msg")))
 }
 
+func TestUDPForwarder_ForwardNilConn(t *testing.T) {
+	forwarder := &UDPForwarder{}
+	err := forwarder.Forward([]byte("msg"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "udp connection is nil")
+}
+
 func TestUDPForwarder_ConcurrentForwarding(t *testing.T) {
 	// Start a mock UDP server
 	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")

--- a/pkg/messaging/messaging.go
+++ b/pkg/messaging/messaging.go
@@ -2,6 +2,9 @@ package messaging
 
 import (
 	"fmt"
+	"net/http"
+	"time"
+
 	"github.com/slack-go/slack"
 )
 
@@ -22,11 +25,12 @@ type SlackMessenger struct {
 }
 
 // NewSlackMessenger creates a new SlackMessenger
-func NewSlackMessenger(serverURL, token, channel string) *SlackMessenger {
+func NewSlackMessenger(serverURL, token, channel string, timeout time.Duration) *SlackMessenger {
 	opts := []slack.Option{}
 	if serverURL != "" {
 		opts = append(opts, slack.OptionAPIURL(serverURL))
 	}
+	opts = append(opts, slack.OptionHTTPClient(&http.Client{Timeout: timeout}))
 	client := slack.New(token, opts...)
 	return &SlackMessenger{client: client, channel: channel}
 }
@@ -43,16 +47,20 @@ func (m *SlackMessenger) Send(message string) error {
 // SlackWebhookMessenger implements the Messenger interface for Slack webhooks
 type SlackWebhookMessenger struct {
 	webhookURL string
+	httpClient *http.Client
 }
 
 // NewSlackWebhookMessenger creates a new SlackWebhookMessenger
-func NewSlackWebhookMessenger(webhookURL string) *SlackWebhookMessenger {
-	return &SlackWebhookMessenger{webhookURL: webhookURL}
+func NewSlackWebhookMessenger(webhookURL string, timeout time.Duration) *SlackWebhookMessenger {
+	return &SlackWebhookMessenger{
+		webhookURL: webhookURL,
+		httpClient: &http.Client{Timeout: timeout},
+	}
 }
 
 // Send sends a message to Slack using a webhook
 func (m *SlackWebhookMessenger) Send(message string) error {
-	err := slack.PostWebhook(m.webhookURL, &slack.WebhookMessage{Text: message})
+	err := slack.PostWebhookCustomHTTP(m.webhookURL, m.httpClient, &slack.WebhookMessage{Text: message})
 	if err != nil {
 		return fmt.Errorf("failed to send message: %w", err)
 	}

--- a/pkg/messaging/messaging_test.go
+++ b/pkg/messaging/messaging_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/slack-go/slack"
 	"github.com/stretchr/testify/assert"
@@ -26,7 +27,7 @@ func TestNewSlackMessenger(t *testing.T) {
 	token := "test-token"
 	channel := "test-channel"
 
-	messenger := NewSlackMessenger(serverURL, token, channel)
+	messenger := NewSlackMessenger(serverURL, token, channel, 0)
 
 	assert.NotNil(t, messenger, "NewSlackMessenger should return a non-nil messenger")
 	assert.Equal(t, channel, messenger.channel, "Channel should be set correctly")
@@ -34,7 +35,7 @@ func TestNewSlackMessenger(t *testing.T) {
 	_, ok := messenger.client.(*slack.Client)
 	assert.True(t, ok, "Client should be of type *slack.Client")
 
-	emptyMessenger := NewSlackMessenger("", "", "")
+	emptyMessenger := NewSlackMessenger("", "", "", 0)
 	assert.NotNil(t, emptyMessenger, "NewSlackMessenger should return a non-nil messenger even with empty inputs")
 	assert.Empty(t, emptyMessenger.channel, "Channel should be empty")
 }
@@ -70,7 +71,7 @@ func TestSlackWebhookMessenger_Send(t *testing.T) {
 	}))
 	defer server.Close()
 
-	messenger := NewSlackWebhookMessenger(server.URL)
+	messenger := NewSlackWebhookMessenger(server.URL, 0)
 	err := messenger.Send("Test message")
 	assert.NoError(t, err)
 }
@@ -81,31 +82,56 @@ func TestSlackWebhookMessenger_SendError(t *testing.T) {
 	}))
 	defer server.Close()
 
-	messenger := NewSlackWebhookMessenger(server.URL)
+	messenger := NewSlackWebhookMessenger(server.URL, 0)
 	err := messenger.Send("Test message")
 	assert.Error(t, err)
 }
 
 func TestNewSlackWebhookMessenger(t *testing.T) {
 	webhookURL := "https://slack.example.com/hooks/abc123"
-	messenger := NewSlackWebhookMessenger(webhookURL)
+	messenger := NewSlackWebhookMessenger(webhookURL, 0)
 
 	assert.NotNil(t, messenger, "NewSlackWebhookMessenger should return a non-nil messenger")
 	assert.Equal(t, webhookURL, messenger.webhookURL, "Webhook URL should be set correctly")
 
-	emptyMessenger := NewSlackWebhookMessenger("")
+	emptyMessenger := NewSlackWebhookMessenger("", 0)
 	assert.NotNil(t, emptyMessenger, "NewSlackWebhookMessenger should return a non-nil messenger even with empty webhook URL")
 	assert.Empty(t, emptyMessenger.webhookURL, "Webhook URL should be empty")
 }
 
 func TestSlackWebhookMessenger_SendInvalidURL(t *testing.T) {
-	messenger := NewSlackWebhookMessenger("http://[::1]:NamedPort")
+	messenger := NewSlackWebhookMessenger("http://[::1]:NamedPort", 0)
 	err := messenger.Send("Test message")
 	assert.Error(t, err)
 }
 
 func TestSlackWebhookMessenger_SendEmptyURL(t *testing.T) {
-	messenger := NewSlackWebhookMessenger("")
+	messenger := NewSlackWebhookMessenger("", 0)
 	err := messenger.Send("Test message")
+	assert.Error(t, err)
+}
+
+func TestSlackWebhookMessenger_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	m := NewSlackWebhookMessenger(srv.URL, 10*time.Millisecond)
+	err := m.Send("msg")
+	assert.Error(t, err)
+}
+
+func TestSlackMessenger_Timeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(50 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+
+	m := NewSlackMessenger(srv.URL, "token", "chan", 10*time.Millisecond)
+	err := m.Send("msg")
 	assert.Error(t, err)
 }


### PR DESCRIPTION
This pull request introduces a robust asynchronous side-effect processing system to the audit server, focusing on improving request-path latency and providing tunable reliability for notifications and forwarding. It adds async configuration options, implements an async worker and queue system, introduces optional durable (persistent) retry support, and updates documentation and configuration accordingly. Performance benchmarking and tuning guidance are also included.

Key changes:

**Asynchronous Side-Effect Processing:**
- Added a new async worker and queue system (`sideTask`, `enqueueSide`, `startSideWorkers`, etc.) to decouple notifications/forwarding from the request path, significantly reducing request latency under load. (`pkg/auditserver/async.go` [[1]](diffhunk://#diff-214cde7b7434e7b07bb1f44bb1792ef3255bd9fba5b33b7dc41aa306d990908eR1-R144) `pkg/auditserver/server.go` [[2]](diffhunk://#diff-1367c9b0c20c80ea4c787543aa30a8f9e4524359e9f774a5ea08682da9fae5a7R136-R148) [[3]](diffhunk://#diff-1367c9b0c20c80ea4c787543aa30a8f9e4524359e9f774a5ea08682da9fae5a7L148-R212) [[4]](diffhunk://#diff-1367c9b0c20c80ea4c787543aa30a8f9e4524359e9f774a5ea08682da9fae5a7R239-R292) [[5]](diffhunk://#diff-1367c9b0c20c80ea4c787543aa30a8f9e4524359e9f774a5ea08682da9fae5a7R368-R395)
- Introduced configuration options for async queue size, worker count, enqueue mode, and timeouts, all with sensible defaults and validation. (`pkg/auditserver/server.go` [[1]](diffhunk://#diff-1367c9b0c20c80ea4c787543aa30a8f9e4524359e9f774a5ea08682da9fae5a7R239-R292) `configs/development/config/config.yaml` [[2]](diffhunk://#diff-34a027bed0b00809fab4b08cc2af6fe86fe51022323af99bf15cffb44751bd2dR1-R5) `README.md` [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R71-R75) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R137-R194)

**Durable Side-Effect Delivery (Optional):**
- Added a file-based persistent side-effect store with dead-letter support for durable retry of failed notifications/forwards, and replay of pending tasks on startup. (`pkg/auditserver/durable.go` [[1]](diffhunk://#diff-aac2c4fcfc83fd8c229cde1dbc66a46ea759fc2ac1d11bfdd297889fd2b60846R1-R155) `pkg/auditserver/server.go` [[2]](diffhunk://#diff-1367c9b0c20c80ea4c787543aa30a8f9e4524359e9f774a5ea08682da9fae5a7R136-R148) [[3]](diffhunk://#diff-1367c9b0c20c80ea4c787543aa30a8f9e4524359e9f774a5ea08682da9fae5a7R239-R292) [[4]](diffhunk://#diff-1367c9b0c20c80ea4c787543aa30a8f9e4524359e9f774a5ea08682da9fae5a7R368-R395)

**Timeouts and Reliability Improvements:**
- Added per-operation timeouts for Slack/webhook messaging and UDP forwarding. (`pkg/auditserver/server.go` [[1]](diffhunk://#diff-1367c9b0c20c80ea4c787543aa30a8f9e4524359e9f774a5ea08682da9fae5a7L255-R338) [[2]](diffhunk://#diff-1367c9b0c20c80ea4c787543aa30a8f9e4524359e9f774a5ea08682da9fae5a7R354-R356) `pkg/forwarder/forwarder.go` [[3]](diffhunk://#diff-a14c4239c1b85a957fd71e7038cf38822e97afc3d2edf4169414bc28d8b12248R4-R7) [[4]](diffhunk://#diff-a14c4239c1b85a957fd71e7038cf38822e97afc3d2edf4169414bc28d8b12248R18-R19) [[5]](diffhunk://#diff-a14c4239c1b85a957fd71e7038cf38822e97afc3d2edf4169414bc28d8b12248R35-R49)
- Updated the forwarding and messaging code to accept and use these timeouts. (`pkg/auditserver/server.go` [[1]](diffhunk://#diff-1367c9b0c20c80ea4c787543aa30a8f9e4524359e9f774a5ea08682da9fae5a7L255-R338) [[2]](diffhunk://#diff-1367c9b0c20c80ea4c787543aa30a8f9e4524359e9f774a5ea08682da9fae5a7R354-R356)

**Documentation and Benchmarking:**
- Expanded documentation with async configuration, tuning profiles, performance findings, and operational guidance for side-effect reliability vs. latency trade-offs. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R71-R75) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R137-R194)
- Added benchmark tests for core logging and rule evaluation paths. (`pkg/auditserver/bench_test.go` [pkg/auditserver/bench_test.goR1-R43](diffhunk://#diff-4928cc6308985a8649cab17eed8ed131a67a8eae2b52cc12ab89f89715d18318R1-R43))