### PR TITLE
deepen audit architecture seams

### DIFF
--- a/cmd/auditServer.go
+++ b/cmd/auditServer.go
@@ -34,7 +34,11 @@ var auditServerCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		server, err := auditserver.New(logger)
+		settings, err := auditServerRuntimeSettings()
+		if err != nil {
+			return fmt.Errorf("failed to create audit server: %w", err)
+		}
+		server, err := auditserver.New(logger, settings)
 		if err != nil {
 			return fmt.Errorf("failed to create audit server: %w", err)
 		}

--- a/cmd/auditServer_test.go
+++ b/cmd/auditServer_test.go
@@ -16,8 +16,11 @@ limitations under the License.
 package cmd
 
 import (
+	"path/filepath"
 	"testing"
+	"time"
 
+	"github.com/ncode/vault-audit-filter/pkg/auditserver"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -54,6 +57,76 @@ func TestAuditServerCmd_ValidConfig(t *testing.T) {
 	assert.NotNil(t, auditServerCmd)
 	assert.Equal(t, "auditServer", auditServerCmd.Use)
 	assert.NotNil(t, auditServerCmd.RunE)
+}
+
+func TestAuditServerRuntimeSettingsFromViper(t *testing.T) {
+	viper.Reset()
+	logPath := filepath.Join(t.TempDir(), "audit.log")
+	viper.Set("vault.audit_protocol", "tcp")
+	viper.Set("async.queue_size", 9)
+	viper.Set("async.workers", 3)
+	viper.Set("async.enqueue_mode", "wait")
+	viper.Set("async.enqueue_timeout", "13ms")
+	viper.Set("async.timeout", "19ms")
+	viper.Set("async.durable.enabled", true)
+	viper.Set("async.durable.dir", t.TempDir())
+	viper.Set("async.retry.max_attempts", 6)
+	viper.Set("async.retry.backoff", "29ms")
+	viper.Set("rule_groups", []map[string]interface{}{{
+		"name":     "configured",
+		"rules":    []string{"Request.Operation == 'read'"},
+		"log_file": map[string]interface{}{"file_path": logPath, "max_size": 1},
+	}})
+
+	settings, err := auditServerRuntimeSettings()
+	require.NoError(t, err)
+	assert.Equal(t, "tcp", settings.AuditProtocol)
+	assert.Equal(t, 9, settings.Async.QueueSize)
+	assert.Equal(t, 3, settings.Async.Workers)
+	assert.Equal(t, "wait", settings.Async.EnqueueMode)
+	assert.Equal(t, 13*time.Millisecond, settings.Async.EnqueueTimeout)
+	assert.Equal(t, 19*time.Millisecond, settings.Async.Timeout)
+	assert.True(t, settings.Async.Durable.Enabled)
+	assert.Equal(t, 6, settings.Async.Retry.MaxAttempts)
+	assert.Equal(t, 29*time.Millisecond, settings.Async.Retry.Backoff)
+	require.Len(t, settings.RuleGroups, 1)
+	assert.Equal(t, "configured", settings.RuleGroups[0].Name)
+	assert.Equal(t, logPath, settings.RuleGroups[0].LogFile.FilePath)
+}
+
+func TestAuditServerRuntimeSettings_InvalidAsyncValuesFallBackToDefaults(t *testing.T) {
+	viper.Reset()
+	viper.Set("vault.audit_protocol", "udp")
+	viper.Set("async.queue_size", 0)
+	viper.Set("async.workers", -1)
+	viper.Set("async.enqueue_mode", "invalid")
+	viper.Set("async.enqueue_timeout", "bad")
+	viper.Set("async.timeout", "also-bad")
+	viper.Set("async.durable.dir", "")
+	viper.Set("async.retry.max_attempts", 0)
+	viper.Set("async.retry.backoff", "worse")
+	viper.Set("rule_groups", []map[string]interface{}{})
+
+	settings, err := auditServerRuntimeSettings()
+	require.NoError(t, err)
+	defaults := auditserver.DefaultRuntimeSettings()
+	assert.Equal(t, defaults.Async.QueueSize, settings.Async.QueueSize)
+	assert.Equal(t, defaults.Async.Workers, settings.Async.Workers)
+	assert.Equal(t, defaults.Async.EnqueueMode, settings.Async.EnqueueMode)
+	assert.Equal(t, defaults.Async.EnqueueTimeout, settings.Async.EnqueueTimeout)
+	assert.Equal(t, defaults.Async.Timeout, settings.Async.Timeout)
+	assert.Equal(t, defaults.Async.Durable.Dir, settings.Async.Durable.Dir)
+	assert.Equal(t, defaults.Async.Retry.MaxAttempts, settings.Async.Retry.MaxAttempts)
+	assert.Equal(t, defaults.Async.Retry.Backoff, settings.Async.Retry.Backoff)
+}
+
+func TestAuditServerRuntimeSettings_InvalidProtocol(t *testing.T) {
+	viper.Reset()
+	viper.Set("vault.audit_protocol", "invalid")
+
+	_, err := auditServerRuntimeSettings()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported vault.audit_protocol")
 }
 
 func TestAuditServerCmd_RunE_InvokesGnetRun(t *testing.T) {

--- a/cmd/audit_config.go
+++ b/cmd/audit_config.go
@@ -1,0 +1,62 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/ncode/vault-audit-filter/pkg/auditserver"
+	"github.com/spf13/viper"
+)
+
+func auditServerRuntimeSettings() (auditserver.RuntimeSettings, error) {
+	defaults := auditserver.DefaultRuntimeSettings()
+	setAuditServerDefaults(defaults)
+
+	var ruleGroups []auditserver.RuleGroupConfig
+	if err := viper.UnmarshalKey("rule_groups", &ruleGroups); err != nil {
+		logger.Error("Failed to load rule groups", "error", err)
+		return auditserver.RuntimeSettings{}, fmt.Errorf("failed to load rule groups: %w", err)
+	}
+
+	protocol, err := vaultAuditProtocol()
+	if err != nil {
+		return auditserver.RuntimeSettings{}, err
+	}
+
+	settings := defaults
+	settings.RuleGroups = ruleGroups
+	settings.AuditProtocol = protocol
+	settings.Async.QueueSize = viper.GetInt("async.queue_size")
+	settings.Async.Workers = viper.GetInt("async.workers")
+	settings.Async.EnqueueMode = viper.GetString("async.enqueue_mode")
+	settings.Async.EnqueueTimeout = durationSetting("async.enqueue_timeout", defaults.Async.EnqueueTimeout)
+	settings.Async.Timeout = durationSetting("async.timeout", defaults.Async.Timeout)
+	settings.Async.Durable.Enabled = viper.GetBool("async.durable.enabled")
+	settings.Async.Durable.Dir = viper.GetString("async.durable.dir")
+	settings.Async.Retry.MaxAttempts = viper.GetInt("async.retry.max_attempts")
+	settings.Async.Retry.Backoff = durationSetting("async.retry.backoff", defaults.Async.Retry.Backoff)
+
+	return auditserver.NormalizeRuntimeSettings(settings, logger), nil
+}
+
+func setAuditServerDefaults(defaults auditserver.RuntimeSettings) {
+	viper.SetDefault("async.queue_size", defaults.Async.QueueSize)
+	viper.SetDefault("async.workers", defaults.Async.Workers)
+	viper.SetDefault("async.enqueue_mode", defaults.Async.EnqueueMode)
+	viper.SetDefault("async.enqueue_timeout", defaults.Async.EnqueueTimeout.String())
+	viper.SetDefault("async.timeout", defaults.Async.Timeout.String())
+	viper.SetDefault("async.durable.enabled", defaults.Async.Durable.Enabled)
+	viper.SetDefault("async.durable.dir", defaults.Async.Durable.Dir)
+	viper.SetDefault("async.retry.max_attempts", defaults.Async.Retry.MaxAttempts)
+	viper.SetDefault("async.retry.backoff", defaults.Async.Retry.Backoff.String())
+}
+
+func durationSetting(key string, fallback time.Duration) time.Duration {
+	raw := viper.GetString(key)
+	value, err := time.ParseDuration(raw)
+	if err != nil || value <= 0 {
+		logger.Warn("Invalid duration config; using default", "key", key, "value", raw)
+		return fallback
+	}
+	return value
+}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -43,17 +43,13 @@ var setupCmd = &cobra.Command{
 			return fmt.Errorf("unable to setup vault client: %w", err)
 		}
 
-		err = client.EnableAuditDevice(
-			viper.GetString("vault.audit_path"),
-			"socket",
-			viper.GetString("vault.audit_description"),
-			map[string]string{
-				"address":     viper.GetString("vault.audit_address"),
-				"socket_type": protocol,
-				"description": viper.GetString("vault.audit_description"),
-				"log_raw":     "false",
-			},
-		)
+		err = client.EnableSocketAuditDevice(vault.SocketAuditDeviceSpec{
+			Path:        viper.GetString("vault.audit_path"),
+			Address:     viper.GetString("vault.audit_address"),
+			Protocol:    protocol,
+			Description: viper.GetString("vault.audit_description"),
+			LogRaw:      false,
+		})
 		if err != nil {
 			return fmt.Errorf("unable to enable audit device: %w", err)
 		}

--- a/integration_test.go
+++ b/integration_test.go
@@ -15,7 +15,6 @@ import (
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/ncode/vault-audit-filter/pkg/auditserver"
 	"github.com/ncode/vault-audit-filter/pkg/vault"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +32,7 @@ func getEnvOrDefault(key, defaultValue string) string {
 	return defaultValue
 }
 
-func tcpAuditAddressFromListener(listenerAddr net.Addr) string {
+func auditAddressFromListener(listenerAddr net.Addr) string {
 	port := "0"
 	if _, p, err := net.SplitHostPort(listenerAddr.String()); err == nil {
 		port = p
@@ -52,77 +51,204 @@ func tcpListenerHost() string {
 	return "0.0.0.0"
 }
 
-func TestIntegration_VaultConnection(t *testing.T) {
-	vaultAddr := getEnvOrDefault("VAULT_ADDR", defaultVaultAddr)
-	vaultToken := getEnvOrDefault("VAULT_TOKEN", defaultVaultToken)
+func newIntegrationVaultClient(t *testing.T) *vault.VaultClient {
+	t.Helper()
+	client, err := vault.NewVaultClient(
+		getEnvOrDefault("VAULT_ADDR", defaultVaultAddr),
+		vault.TokenAuth{Token: getEnvOrDefault("VAULT_TOKEN", defaultVaultToken)},
+	)
+	require.NoError(t, err)
+	return client
+}
 
-	client, err := vault.NewVaultClient(vaultAddr, vault.TokenAuth{Token: vaultToken})
-	require.NoError(t, err, "Failed to connect to Vault")
-	require.NotNil(t, client)
+func integrationLogFile(path string) auditserver.LogFileConfig {
+	return auditserver.LogFileConfig{
+		FilePath:   path,
+		MaxSize:    10,
+		MaxBackups: 1,
+		MaxAge:     1,
+		Compress:   false,
+	}
+}
+
+func newIntegrationAuditServer(t *testing.T, protocol string, ruleGroups []auditserver.RuleGroupConfig) *auditserver.AuditServer {
+	t.Helper()
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	settings := auditserver.DefaultRuntimeSettings()
+	settings.AuditProtocol = protocol
+	settings.RuleGroups = ruleGroups
+	server, err := auditserver.New(logger, settings)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	return server
+}
+
+func startUDPAuditListener(t *testing.T, server *auditserver.AuditServer) string {
+	t.Helper()
+	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	conn, err := net.ListenUDP("udp", addr)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		close(done)
+		_ = conn.Close()
+	})
+
+	go func() {
+		buf := make([]byte, 65535)
+		for {
+			select {
+			case <-done:
+				return
+			default:
+				_ = conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+				n, _, err := conn.ReadFromUDP(buf)
+				if err != nil {
+					continue
+				}
+				server.React(buf[:n], nil)
+			}
+		}
+	}()
+
+	return auditAddressFromListener(conn.LocalAddr())
+}
+
+func startTCPAuditListener(t *testing.T, server *auditserver.AuditServer) string {
+	t.Helper()
+	tcpListenAddr := net.JoinHostPort(tcpListenerHost(), "0")
+	addr, err := net.ResolveTCPAddr("tcp", tcpListenAddr)
+	require.NoError(t, err)
+
+	listener, err := net.ListenTCP("tcp", addr)
+	require.NoError(t, err)
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		close(stop)
+		_ = listener.Close()
+		select {
+		case <-done:
+		case <-time.After(time.Second):
+		}
+	})
+
+	go func() {
+		defer close(done)
+
+		conn, acceptErr := listener.Accept()
+		if acceptErr != nil {
+			return
+		}
+		defer conn.Close()
+
+		buf := make([]byte, 65535)
+		carry := make([]byte, 0)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+			n, readErr := conn.Read(buf)
+			if n > 0 {
+				carry = append(carry, buf[:n]...)
+
+				for {
+					idx := bytes.IndexByte(carry, '\n')
+					if idx < 0 {
+						break
+					}
+
+					frame := bytes.TrimSuffix(carry[:idx], []byte{'\r'})
+					if len(frame) > 0 {
+						server.React(frame, nil)
+					}
+
+					if idx+1 >= len(carry) {
+						carry = carry[:0]
+					} else {
+						carry = carry[idx+1:]
+					}
+				}
+			}
+
+			if readErr != nil {
+				if netErr, ok := readErr.(net.Error); ok && netErr.Timeout() {
+					continue
+				}
+				return
+			}
+		}
+	}()
+
+	return auditAddressFromListener(listener.Addr())
+}
+
+func enableSocketAudit(t *testing.T, client *vault.VaultClient, path, address, protocol, description string) {
+	t.Helper()
+	_ = client.Sys().DisableAudit(path)
+	err := client.EnableSocketAuditDevice(vault.SocketAuditDeviceSpec{
+		Path:        path,
+		Address:     address,
+		Protocol:    protocol,
+		Description: description,
+		LogRaw:      false,
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = client.Sys().DisableAudit(path)
+	})
+}
+
+func waitForLogFile(t *testing.T, path string) string {
+	t.Helper()
+	var content []byte
+	require.Eventually(t, func() bool {
+		var err error
+		content, err = os.ReadFile(path)
+		return err == nil && len(content) > 0
+	}, 2*time.Second, 50*time.Millisecond)
+	return string(content)
+}
+
+func readLogFile(path string) string {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(content)
+}
+
+func TestIntegration_VaultConnection(t *testing.T) {
+	client := newIntegrationVaultClient(t)
 
 	// Verify we can list auth methods (proves connection works)
-	_, err = client.Sys().ListAuth()
+	_, err := client.Sys().ListAuth()
 	assert.NoError(t, err, "Failed to list auth methods")
 }
 
 func TestIntegration_EnableAuditDevice(t *testing.T) {
-	vaultAddr := getEnvOrDefault("VAULT_ADDR", defaultVaultAddr)
-	vaultToken := getEnvOrDefault("VAULT_TOKEN", defaultVaultToken)
 	auditAddr := getEnvOrDefault("AUDIT_ADDR", defaultAuditAddr)
 
-	client, err := vault.NewVaultClient(vaultAddr, vault.TokenAuth{Token: vaultToken})
-	require.NoError(t, err)
-
-	// Clean up any existing audit device from previous test runs
-	_ = client.Sys().DisableAudit("integration-test")
-
-	// Enable the audit device
-	err = client.EnableAuditDevice(
-		"integration-test",
-		"socket",
-		"Integration test audit device",
-		map[string]string{
-			"address":     auditAddr,
-			"socket_type": "udp",
-			"log_raw":     "false",
-		},
-	)
-	require.NoError(t, err, "Failed to enable audit device")
+	client := newIntegrationVaultClient(t)
+	enableSocketAudit(t, client, "integration-test", auditAddr, "udp", "Integration test audit device")
 
 	// Verify it was enabled
 	audits, err := client.Sys().ListAudit()
 	require.NoError(t, err)
 	assert.Contains(t, audits, "integration-test/", "Audit device should be enabled")
-
-	// Clean up
-	err = client.Sys().DisableAudit("integration-test")
-	assert.NoError(t, err)
 }
 
 func TestIntegration_AuditDeviceWithSocketConfig(t *testing.T) {
-	vaultAddr := getEnvOrDefault("VAULT_ADDR", defaultVaultAddr)
-	vaultToken := getEnvOrDefault("VAULT_TOKEN", defaultVaultToken)
-
-	// Connect to Vault
-	client, err := vault.NewVaultClient(vaultAddr, vault.TokenAuth{Token: vaultToken})
-	require.NoError(t, err)
-
-	// Clean up any existing audit device
-	_ = client.Sys().DisableAudit("integration-socket-test")
-
-	// Enable audit device with socket configuration
-	// Use a dummy address - we're testing the API works, not actual delivery
-	err = client.EnableAuditDevice(
-		"integration-socket-test",
-		"socket",
-		"Integration socket test",
-		map[string]string{
-			"address":     "127.0.0.1:19999",
-			"socket_type": "udp",
-			"log_raw":     "false",
-		},
-	)
-	require.NoError(t, err, "Should be able to enable socket audit device")
+	client := newIntegrationVaultClient(t)
+	enableSocketAudit(t, client, "integration-socket-test", "127.0.0.1:19999", "udp", "Integration socket test")
 
 	// Verify the audit device is enabled
 	audits, err := client.Sys().ListAudit()
@@ -153,95 +279,30 @@ func TestIntegration_AuditDeviceWithSocketConfig(t *testing.T) {
 		t.Logf("Write operation result: %v (expected in some configurations)", err)
 	}
 
-	// Clean up
-	_ = client.Sys().DisableAudit("integration-socket-test")
 	_ = client.Sys().Unmount("integration-kv")
 }
 
 func TestIntegration_AuditServerWithRules(t *testing.T) {
-	vaultAddr := getEnvOrDefault("VAULT_ADDR", defaultVaultAddr)
-	vaultToken := getEnvOrDefault("VAULT_TOKEN", defaultVaultToken)
-
-	// Create a temp file for audit logs
 	tmpDir := t.TempDir()
 	logFile := tmpDir + "/audit.log"
 
-	// Configure viper with rule groups
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	server := newIntegrationAuditServer(t, "udp", []auditserver.RuleGroupConfig{
 		{
-			"name": "all_operations",
-			"rules": []string{
+			Name: "all_operations",
+			Rules: []string{
 				"Auth.PolicyResults.Allowed == true",
 			},
-			"log_file": map[string]interface{}{
-				"file_path":   logFile,
-				"max_size":    10,
-				"max_backups": 1,
-				"max_age":     1,
-				"compress":    false,
-			},
+			LogFile: integrationLogFile(logFile),
 		},
 	})
-
-	// Create the audit server
-	var logBuf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	server, err := auditserver.New(logger)
-	require.NoError(t, err)
-	require.NotNil(t, server)
-
-	// Start a UDP listener
-	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	require.NoError(t, err)
-
-	conn, err := net.ListenUDP("udp", addr)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	localAddr := conn.LocalAddr().String()
+	localAddr := startUDPAuditListener(t, server)
 	t.Logf("Audit server listening on %s", localAddr)
 
-	// Process incoming messages in a goroutine
-	done := make(chan struct{})
-	go func() {
-		buf := make([]byte, 65535)
-		for {
-			select {
-			case <-done:
-				return
-			default:
-				conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
-				n, _, err := conn.ReadFromUDP(buf)
-				if err != nil {
-					continue
-				}
-				// Process through the audit server
-				server.React(buf[:n], nil)
-			}
-		}
-	}()
-
-	// Connect to Vault and enable audit device
-	client, err := vault.NewVaultClient(vaultAddr, vault.TokenAuth{Token: vaultToken})
-	require.NoError(t, err)
-
-	_ = client.Sys().DisableAudit("integration-rules-test")
-
-	err = client.EnableAuditDevice(
-		"integration-rules-test",
-		"socket",
-		"Integration rules test",
-		map[string]string{
-			"address":     localAddr,
-			"socket_type": "udp",
-			"log_raw":     "false",
-		},
-	)
-	require.NoError(t, err)
+	client := newIntegrationVaultClient(t)
+	enableSocketAudit(t, client, "integration-rules-test", localAddr, "udp", "Integration rules test")
 
 	// Perform Vault operations
-	err = client.Sys().Mount("integration-kv-rules", &vaultapi.MountInput{
+	err := client.Sys().Mount("integration-kv-rules", &vaultapi.MountInput{
 		Type:        "kv",
 		Description: "Integration test KV for rules",
 		Options:     map[string]string{"version": "2"},
@@ -255,121 +316,31 @@ func TestIntegration_AuditServerWithRules(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Wait for processing
-	time.Sleep(500 * time.Millisecond)
-	close(done)
+	logContent := waitForLogFile(t, logFile)
+	t.Logf("Audit log file contains %d bytes", len(logContent))
 
-	// Check that logs were written
-	logContent, err := os.ReadFile(logFile)
-	if err == nil && len(logContent) > 0 {
-		t.Logf("Audit log file contains %d bytes", len(logContent))
-		assert.True(t, len(logContent) > 0, "Should have written audit logs")
-	}
-
-	// Clean up
-	_ = client.Sys().DisableAudit("integration-rules-test")
 	_ = client.Sys().Unmount("integration-kv-rules")
 }
 
 func TestIntegration_AuditServerWithRules_TCP(t *testing.T) {
-	vaultAddr := getEnvOrDefault("VAULT_ADDR", defaultVaultAddr)
-	vaultToken := getEnvOrDefault("VAULT_TOKEN", defaultVaultToken)
-
 	tmpDir := t.TempDir()
 	logFile := tmpDir + "/audit-tcp.log"
 
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	server := newIntegrationAuditServer(t, "tcp", []auditserver.RuleGroupConfig{
 		{
-			"name": "all_tcp",
-			"rules": []string{
+			Name: "all_tcp",
+			Rules: []string{
 				"true",
 			},
-			"log_file": map[string]interface{}{
-				"file_path":   logFile,
-				"max_size":    10,
-				"max_backups": 1,
-				"max_age":     1,
-				"compress":    false,
-			},
+			LogFile: integrationLogFile(logFile),
 		},
 	})
+	auditAddress := startTCPAuditListener(t, server)
 
-	var logBuf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	server, err := auditserver.New(logger)
-	require.NoError(t, err)
-	require.NotNil(t, server)
+	client := newIntegrationVaultClient(t)
+	enableSocketAudit(t, client, "integration-rules-tcp-test", auditAddress, "tcp", "Integration TCP rules test")
 
-	tcpListenAddr := net.JoinHostPort(tcpListenerHost(), "0")
-	addr, err := net.ResolveTCPAddr("tcp", tcpListenAddr)
-	require.NoError(t, err)
-
-	auditListener, err := net.ListenTCP("tcp", addr)
-	require.NoError(t, err)
-	defer auditListener.Close()
-
-	auditDone := make(chan struct{})
-	go func() {
-		defer close(auditDone)
-
-		conn, acceptErr := auditListener.Accept()
-		if acceptErr != nil {
-			return
-		}
-		defer conn.Close()
-
-		buf := make([]byte, 65535)
-		carry := make([]byte, 0)
-		for {
-			n, readErr := conn.Read(buf)
-			if n > 0 {
-				carry = append(carry, buf[:n]...)
-
-				for {
-					idx := bytes.IndexByte(carry, '\n')
-					if idx < 0 {
-						break
-					}
-
-					frame := carry[:idx]
-					frame = bytes.TrimSuffix(frame, []byte{'\r'})
-					if len(frame) > 0 {
-						server.React(frame, nil)
-					}
-
-					if idx+1 >= len(carry) {
-						carry = carry[:0]
-					} else {
-						carry = carry[idx+1:]
-					}
-				}
-			}
-
-			if readErr != nil {
-				return
-			}
-		}
-	}()
-
-	client, err := vault.NewVaultClient(vaultAddr, vault.TokenAuth{Token: vaultToken})
-	require.NoError(t, err)
-
-	_ = client.Sys().DisableAudit("integration-rules-tcp-test")
-
-	err = client.EnableAuditDevice(
-		"integration-rules-tcp-test",
-		"socket",
-		"Integration TCP rules test",
-		map[string]string{
-			"address":     tcpAuditAddressFromListener(auditListener.Addr()),
-			"socket_type": "tcp",
-			"log_raw":     "false",
-		},
-	)
-	require.NoError(t, err)
-
-	err = client.Sys().Mount("integration-kv-rules-tcp", &vaultapi.MountInput{
+	err := client.Sys().Mount("integration-kv-rules-tcp", &vaultapi.MountInput{
 		Type:        "kv",
 		Description: "Integration test KV for tcp rules",
 		Options:     map[string]string{"version": "2"},
@@ -383,22 +354,13 @@ func TestIntegration_AuditServerWithRules_TCP(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	time.Sleep(1 * time.Second)
-
-	_ = client.Sys().DisableAudit("integration-rules-tcp-test")
 	_ = client.Sys().Unmount("integration-kv-rules-tcp")
-	_ = auditListener.Close()
-	<-auditDone
 
-	content, err := os.ReadFile(logFile)
-	require.NoError(t, err)
+	content := waitForLogFile(t, logFile)
 	assert.Greater(t, len(content), 0, "should have written audit logs over TCP")
 }
 
 func TestIntegration_AuditServerForwarding(t *testing.T) {
-	vaultAddr := getEnvOrDefault("VAULT_ADDR", defaultVaultAddr)
-	vaultToken := getEnvOrDefault("VAULT_TOKEN", defaultVaultToken)
-
 	// Start a UDP receiver for forwarded messages
 	forwardAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
 	require.NoError(t, err)
@@ -438,81 +400,21 @@ func TestIntegration_AuditServerForwarding(t *testing.T) {
 	tmpDir := t.TempDir()
 	logFile := tmpDir + "/audit.log"
 
-	// Configure viper with forwarding enabled
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	server := newIntegrationAuditServer(t, "udp", []auditserver.RuleGroupConfig{
 		{
-			"name": "forward_all",
-			"rules": []string{
+			Name: "forward_all",
+			Rules: []string{
 				"true", // Match everything
 			},
-			"log_file": map[string]interface{}{
-				"file_path":   logFile,
-				"max_size":    10,
-				"max_backups": 1,
-				"max_age":     1,
-				"compress":    false,
-			},
-			"forwarding": map[string]interface{}{
-				"enabled": true,
-				"address": forwardLocalAddr,
-			},
+			LogFile:    integrationLogFile(logFile),
+			Forwarding: auditserver.ForwardingConfig{Enabled: true, Address: forwardLocalAddr},
 		},
 	})
-
-	// Create the audit server
-	var logBuf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	server, err := auditserver.New(logger)
-	require.NoError(t, err)
-
-	// Start audit server listener
-	auditAddr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	require.NoError(t, err)
-
-	auditConn, err := net.ListenUDP("udp", auditAddr)
-	require.NoError(t, err)
-	defer auditConn.Close()
-
-	auditLocalAddr := auditConn.LocalAddr().String()
+	auditLocalAddr := startUDPAuditListener(t, server)
 	t.Logf("Audit server listening on %s", auditLocalAddr)
 
-	// Process incoming messages
-	auditDone := make(chan struct{})
-	go func() {
-		buf := make([]byte, 65535)
-		for {
-			select {
-			case <-auditDone:
-				return
-			default:
-				auditConn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
-				n, _, err := auditConn.ReadFromUDP(buf)
-				if err != nil {
-					continue
-				}
-				server.React(buf[:n], nil)
-			}
-		}
-	}()
-
-	// Connect to Vault
-	client, err := vault.NewVaultClient(vaultAddr, vault.TokenAuth{Token: vaultToken})
-	require.NoError(t, err)
-
-	_ = client.Sys().DisableAudit("integration-forward-test")
-
-	err = client.EnableAuditDevice(
-		"integration-forward-test",
-		"socket",
-		"Integration forward test",
-		map[string]string{
-			"address":     auditLocalAddr,
-			"socket_type": "udp",
-			"log_raw":     "false",
-		},
-	)
-	require.NoError(t, err)
+	client := newIntegrationVaultClient(t)
+	enableSocketAudit(t, client, "integration-forward-test", auditLocalAddr, "udp", "Integration forward test")
 
 	// Perform Vault operations
 	err = client.Sys().Mount("integration-kv-forward", &vaultapi.MountInput{
@@ -529,9 +431,11 @@ func TestIntegration_AuditServerForwarding(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Wait for processing
-	time.Sleep(500 * time.Millisecond)
-	close(auditDone)
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(forwarded) > 0
+	}, 2*time.Second, 50*time.Millisecond)
 	close(forwardDone)
 
 	// Verify forwarding worked
@@ -540,102 +444,38 @@ func TestIntegration_AuditServerForwarding(t *testing.T) {
 
 	t.Logf("Received %d forwarded messages", len(forwarded))
 
-	// Clean up
-	_ = client.Sys().DisableAudit("integration-forward-test")
 	_ = client.Sys().Unmount("integration-kv-forward")
 }
 
 // TestIntegration_OperationFiltering tests rules that filter by operation type
 func TestIntegration_OperationFiltering(t *testing.T) {
-	vaultAddr := getEnvOrDefault("VAULT_ADDR", defaultVaultAddr)
-	vaultToken := getEnvOrDefault("VAULT_TOKEN", defaultVaultToken)
-
 	tmpDir := t.TempDir()
 	deleteLogFile := tmpDir + "/delete_ops.log"
 	readLogFile := tmpDir + "/read_ops.log"
 
-	// Configure two rule groups: one for deletes, one for reads
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	server := newIntegrationAuditServer(t, "udp", []auditserver.RuleGroupConfig{
 		{
-			"name": "delete_operations",
-			"rules": []string{
+			Name: "delete_operations",
+			Rules: []string{
 				`Request.Operation == "delete"`,
 			},
-			"log_file": map[string]interface{}{
-				"file_path":   deleteLogFile,
-				"max_size":    10,
-				"max_backups": 1,
-				"max_age":     1,
-				"compress":    false,
-			},
+			LogFile: integrationLogFile(deleteLogFile),
 		},
 		{
-			"name": "read_operations",
-			"rules": []string{
+			Name: "read_operations",
+			Rules: []string{
 				`Request.Operation == "read"`,
 			},
-			"log_file": map[string]interface{}{
-				"file_path":   readLogFile,
-				"max_size":    10,
-				"max_backups": 1,
-				"max_age":     1,
-				"compress":    false,
-			},
+			LogFile: integrationLogFile(readLogFile),
 		},
 	})
+	localAddr := startUDPAuditListener(t, server)
 
-	var logBuf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	server, err := auditserver.New(logger)
-	require.NoError(t, err)
-
-	// Start UDP listener
-	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	require.NoError(t, err)
-	conn, err := net.ListenUDP("udp", addr)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	localAddr := conn.LocalAddr().String()
-
-	done := make(chan struct{})
-	go func() {
-		buf := make([]byte, 65535)
-		for {
-			select {
-			case <-done:
-				return
-			default:
-				conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
-				n, _, err := conn.ReadFromUDP(buf)
-				if err != nil {
-					continue
-				}
-				server.React(buf[:n], nil)
-			}
-		}
-	}()
-
-	client, err := vault.NewVaultClient(vaultAddr, vault.TokenAuth{Token: vaultToken})
-	require.NoError(t, err)
-
-	_ = client.Sys().DisableAudit("integration-op-filter-test")
-
-	err = client.EnableAuditDevice(
-		"integration-op-filter-test",
-		"socket",
-		"Integration operation filter test",
-		map[string]string{
-			"address":     localAddr,
-			"socket_type": "udp",
-			"log_raw":     "false",
-		},
-	)
-	require.NoError(t, err)
+	client := newIntegrationVaultClient(t)
+	enableSocketAudit(t, client, "integration-op-filter-test", localAddr, "udp", "Integration operation filter test")
 
 	// Setup KV engine
-	err = client.Sys().Mount("integration-kv-opfilter", &vaultapi.MountInput{
+	err := client.Sys().Mount("integration-kv-opfilter", &vaultapi.MountInput{
 		Type:        "kv",
 		Description: "Integration test KV for op filtering",
 		Options:     map[string]string{"version": "2"},
@@ -658,117 +498,45 @@ func TestIntegration_OperationFiltering(t *testing.T) {
 	_, err = client.Logical().Delete("integration-kv-opfilter/data/test")
 	require.NoError(t, err)
 
-	time.Sleep(500 * time.Millisecond)
-	close(done)
+	deleteContent := waitForLogFile(t, deleteLogFile)
+	t.Logf("Delete operations log contains %d bytes", len(deleteContent))
+	assert.Contains(t, deleteContent, "delete", "Should contain delete operations")
 
-	// Check delete log file
-	deleteContent, err := os.ReadFile(deleteLogFile)
-	if err == nil && len(deleteContent) > 0 {
-		t.Logf("Delete operations log contains %d bytes", len(deleteContent))
-		assert.Contains(t, string(deleteContent), "delete", "Should contain delete operations")
-	}
+	readContent := waitForLogFile(t, readLogFile)
+	t.Logf("Read operations log contains %d bytes", len(readContent))
+	assert.Contains(t, readContent, "read", "Should contain read operations")
 
-	// Check read log file
-	readContent, err := os.ReadFile(readLogFile)
-	if err == nil && len(readContent) > 0 {
-		t.Logf("Read operations log contains %d bytes", len(readContent))
-		assert.Contains(t, string(readContent), "read", "Should contain read operations")
-	}
-
-	// Clean up
-	_ = client.Sys().DisableAudit("integration-op-filter-test")
 	_ = client.Sys().Unmount("integration-kv-opfilter")
 }
 
 // TestIntegration_PathBasedRules tests rules that filter by request path
 func TestIntegration_PathBasedRules(t *testing.T) {
-	vaultAddr := getEnvOrDefault("VAULT_ADDR", defaultVaultAddr)
-	vaultToken := getEnvOrDefault("VAULT_TOKEN", defaultVaultToken)
-
 	tmpDir := t.TempDir()
 	secretsLogFile := tmpDir + "/secrets.log"
 	metadataLogFile := tmpDir + "/metadata.log"
 
-	// Configure rules for different paths
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	server := newIntegrationAuditServer(t, "udp", []auditserver.RuleGroupConfig{
 		{
-			"name": "secrets_path",
-			"rules": []string{
+			Name: "secrets_path",
+			Rules: []string{
 				`Request.Path startsWith "integration-kv-path/data/"`,
 			},
-			"log_file": map[string]interface{}{
-				"file_path":   secretsLogFile,
-				"max_size":    10,
-				"max_backups": 1,
-				"max_age":     1,
-				"compress":    false,
-			},
+			LogFile: integrationLogFile(secretsLogFile),
 		},
 		{
-			"name": "metadata_path",
-			"rules": []string{
+			Name: "metadata_path",
+			Rules: []string{
 				`Request.Path startsWith "integration-kv-path/metadata/"`,
 			},
-			"log_file": map[string]interface{}{
-				"file_path":   metadataLogFile,
-				"max_size":    10,
-				"max_backups": 1,
-				"max_age":     1,
-				"compress":    false,
-			},
+			LogFile: integrationLogFile(metadataLogFile),
 		},
 	})
+	localAddr := startUDPAuditListener(t, server)
 
-	var logBuf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	server, err := auditserver.New(logger)
-	require.NoError(t, err)
+	client := newIntegrationVaultClient(t)
+	enableSocketAudit(t, client, "integration-path-test", localAddr, "udp", "Integration path test")
 
-	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	require.NoError(t, err)
-	conn, err := net.ListenUDP("udp", addr)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	localAddr := conn.LocalAddr().String()
-
-	done := make(chan struct{})
-	go func() {
-		buf := make([]byte, 65535)
-		for {
-			select {
-			case <-done:
-				return
-			default:
-				conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
-				n, _, err := conn.ReadFromUDP(buf)
-				if err != nil {
-					continue
-				}
-				server.React(buf[:n], nil)
-			}
-		}
-	}()
-
-	client, err := vault.NewVaultClient(vaultAddr, vault.TokenAuth{Token: vaultToken})
-	require.NoError(t, err)
-
-	_ = client.Sys().DisableAudit("integration-path-test")
-
-	err = client.EnableAuditDevice(
-		"integration-path-test",
-		"socket",
-		"Integration path test",
-		map[string]string{
-			"address":     localAddr,
-			"socket_type": "udp",
-			"log_raw":     "false",
-		},
-	)
-	require.NoError(t, err)
-
-	err = client.Sys().Mount("integration-kv-path", &vaultapi.MountInput{
+	err := client.Sys().Mount("integration-kv-path", &vaultapi.MountInput{
 		Type:        "kv",
 		Description: "Integration test KV for path filtering",
 		Options:     map[string]string{"version": "2"},
@@ -787,103 +555,37 @@ func TestIntegration_PathBasedRules(t *testing.T) {
 	_, err = client.Logical().Read("integration-kv-path/metadata/mysecret")
 	require.NoError(t, err)
 
-	time.Sleep(500 * time.Millisecond)
-	close(done)
+	secretsContent := waitForLogFile(t, secretsLogFile)
+	t.Logf("Secrets path log contains %d bytes", len(secretsContent))
+	assert.Contains(t, secretsContent, "integration-kv-path/data/", "Should contain data path operations")
 
-	// Check secrets log
-	secretsContent, err := os.ReadFile(secretsLogFile)
-	if err == nil && len(secretsContent) > 0 {
-		t.Logf("Secrets path log contains %d bytes", len(secretsContent))
-		assert.Contains(t, string(secretsContent), "integration-kv-path/data/", "Should contain data path operations")
-	}
+	metadataContent := waitForLogFile(t, metadataLogFile)
+	t.Logf("Metadata path log contains %d bytes", len(metadataContent))
+	assert.Contains(t, metadataContent, "integration-kv-path/metadata/", "Should contain metadata path operations")
 
-	// Check metadata log
-	metadataContent, err := os.ReadFile(metadataLogFile)
-	if err == nil && len(metadataContent) > 0 {
-		t.Logf("Metadata path log contains %d bytes", len(metadataContent))
-		assert.Contains(t, string(metadataContent), "integration-kv-path/metadata/", "Should contain metadata path operations")
-	}
-
-	// Clean up
-	_ = client.Sys().DisableAudit("integration-path-test")
 	_ = client.Sys().Unmount("integration-kv-path")
 }
 
 // TestIntegration_CombinedConditions tests rules with AND conditions
 func TestIntegration_CombinedConditions(t *testing.T) {
-	vaultAddr := getEnvOrDefault("VAULT_ADDR", defaultVaultAddr)
-	vaultToken := getEnvOrDefault("VAULT_TOKEN", defaultVaultToken)
-
 	tmpDir := t.TempDir()
 	combinedLogFile := tmpDir + "/combined.log"
 
-	// Rule: only match allowed updates to specific path
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	server := newIntegrationAuditServer(t, "udp", []auditserver.RuleGroupConfig{
 		{
-			"name": "combined_rule",
-			"rules": []string{
+			Name: "combined_rule",
+			Rules: []string{
 				`Request.Operation == "update" && Auth.PolicyResults.Allowed == true`,
 			},
-			"log_file": map[string]interface{}{
-				"file_path":   combinedLogFile,
-				"max_size":    10,
-				"max_backups": 1,
-				"max_age":     1,
-				"compress":    false,
-			},
+			LogFile: integrationLogFile(combinedLogFile),
 		},
 	})
+	localAddr := startUDPAuditListener(t, server)
 
-	var logBuf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	server, err := auditserver.New(logger)
-	require.NoError(t, err)
+	client := newIntegrationVaultClient(t)
+	enableSocketAudit(t, client, "integration-combined-test", localAddr, "udp", "Integration combined test")
 
-	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	require.NoError(t, err)
-	conn, err := net.ListenUDP("udp", addr)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	localAddr := conn.LocalAddr().String()
-
-	done := make(chan struct{})
-	go func() {
-		buf := make([]byte, 65535)
-		for {
-			select {
-			case <-done:
-				return
-			default:
-				conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
-				n, _, err := conn.ReadFromUDP(buf)
-				if err != nil {
-					continue
-				}
-				server.React(buf[:n], nil)
-			}
-		}
-	}()
-
-	client, err := vault.NewVaultClient(vaultAddr, vault.TokenAuth{Token: vaultToken})
-	require.NoError(t, err)
-
-	_ = client.Sys().DisableAudit("integration-combined-test")
-
-	err = client.EnableAuditDevice(
-		"integration-combined-test",
-		"socket",
-		"Integration combined test",
-		map[string]string{
-			"address":     localAddr,
-			"socket_type": "udp",
-			"log_raw":     "false",
-		},
-	)
-	require.NoError(t, err)
-
-	err = client.Sys().Mount("integration-kv-combined", &vaultapi.MountInput{
+	err := client.Sys().Mount("integration-kv-combined", &vaultapi.MountInput{
 		Type:        "kv",
 		Description: "Integration test KV for combined rules",
 		Options:     map[string]string{"version": "2"},
@@ -902,126 +604,50 @@ func TestIntegration_CombinedConditions(t *testing.T) {
 	_, err = client.Logical().Read("integration-kv-combined/data/test")
 	require.NoError(t, err)
 
-	time.Sleep(500 * time.Millisecond)
-	close(done)
+	combinedContent := waitForLogFile(t, combinedLogFile)
+	t.Logf("Combined conditions log contains %d bytes", len(combinedContent))
+	assert.Contains(t, combinedContent, "update", "Should contain update operations")
+	assert.NotContains(t, combinedContent, `"operation":"read"`, "Should not contain read operations")
 
-	// Verify combined log only has updates
-	combinedContent, err := os.ReadFile(combinedLogFile)
-	if err == nil && len(combinedContent) > 0 {
-		t.Logf("Combined conditions log contains %d bytes", len(combinedContent))
-		assert.Contains(t, string(combinedContent), "update", "Should contain update operations")
-		// Should not contain read operations
-		assert.NotContains(t, string(combinedContent), `"operation":"read"`, "Should not contain read operations")
-	}
-
-	// Clean up
-	_ = client.Sys().DisableAudit("integration-combined-test")
 	_ = client.Sys().Unmount("integration-kv-combined")
 }
 
 // TestIntegration_MultipleRuleGroups tests that logs route to correct groups
 func TestIntegration_MultipleRuleGroups(t *testing.T) {
-	vaultAddr := getEnvOrDefault("VAULT_ADDR", defaultVaultAddr)
-	vaultToken := getEnvOrDefault("VAULT_TOKEN", defaultVaultToken)
-
 	tmpDir := t.TempDir()
 	group1Log := tmpDir + "/group1.log"
 	group2Log := tmpDir + "/group2.log"
 	group3Log := tmpDir + "/group3.log"
 
-	// Three different rule groups
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	server := newIntegrationAuditServer(t, "udp", []auditserver.RuleGroupConfig{
 		{
-			"name": "group1_updates",
-			"rules": []string{
+			Name: "group1_updates",
+			Rules: []string{
 				`Request.Operation == "update"`,
 			},
-			"log_file": map[string]interface{}{
-				"file_path":   group1Log,
-				"max_size":    10,
-				"max_backups": 1,
-				"max_age":     1,
-				"compress":    false,
-			},
+			LogFile: integrationLogFile(group1Log),
 		},
 		{
-			"name": "group2_reads",
-			"rules": []string{
+			Name: "group2_reads",
+			Rules: []string{
 				`Request.Operation == "read"`,
 			},
-			"log_file": map[string]interface{}{
-				"file_path":   group2Log,
-				"max_size":    10,
-				"max_backups": 1,
-				"max_age":     1,
-				"compress":    false,
-			},
+			LogFile: integrationLogFile(group2Log),
 		},
 		{
-			"name": "group3_deletes",
-			"rules": []string{
+			Name: "group3_deletes",
+			Rules: []string{
 				`Request.Operation == "delete"`,
 			},
-			"log_file": map[string]interface{}{
-				"file_path":   group3Log,
-				"max_size":    10,
-				"max_backups": 1,
-				"max_age":     1,
-				"compress":    false,
-			},
+			LogFile: integrationLogFile(group3Log),
 		},
 	})
+	localAddr := startUDPAuditListener(t, server)
 
-	var logBuf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	server, err := auditserver.New(logger)
-	require.NoError(t, err)
+	client := newIntegrationVaultClient(t)
+	enableSocketAudit(t, client, "integration-multigroup-test", localAddr, "udp", "Integration multi-group test")
 
-	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	require.NoError(t, err)
-	conn, err := net.ListenUDP("udp", addr)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	localAddr := conn.LocalAddr().String()
-
-	done := make(chan struct{})
-	go func() {
-		buf := make([]byte, 65535)
-		for {
-			select {
-			case <-done:
-				return
-			default:
-				conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
-				n, _, err := conn.ReadFromUDP(buf)
-				if err != nil {
-					continue
-				}
-				server.React(buf[:n], nil)
-			}
-		}
-	}()
-
-	client, err := vault.NewVaultClient(vaultAddr, vault.TokenAuth{Token: vaultToken})
-	require.NoError(t, err)
-
-	_ = client.Sys().DisableAudit("integration-multigroup-test")
-
-	err = client.EnableAuditDevice(
-		"integration-multigroup-test",
-		"socket",
-		"Integration multi-group test",
-		map[string]string{
-			"address":     localAddr,
-			"socket_type": "udp",
-			"log_raw":     "false",
-		},
-	)
-	require.NoError(t, err)
-
-	err = client.Sys().Mount("integration-kv-multigroup", &vaultapi.MountInput{
+	err := client.Sys().Mount("integration-kv-multigroup", &vaultapi.MountInput{
 		Type:        "kv",
 		Description: "Integration test KV for multi-group",
 		Options:     map[string]string{"version": "2"},
@@ -1042,109 +668,41 @@ func TestIntegration_MultipleRuleGroups(t *testing.T) {
 	_, err = client.Logical().Delete("integration-kv-multigroup/data/test")
 	require.NoError(t, err)
 
-	time.Sleep(500 * time.Millisecond)
-	close(done)
-
-	// Verify each group has the right operations
-	group1Content, _ := os.ReadFile(group1Log)
-	group2Content, _ := os.ReadFile(group2Log)
-	group3Content, _ := os.ReadFile(group3Log)
+	group1Content := waitForLogFile(t, group1Log)
+	group2Content := waitForLogFile(t, group2Log)
+	group3Content := waitForLogFile(t, group3Log)
 
 	t.Logf("Group1 (updates): %d bytes", len(group1Content))
 	t.Logf("Group2 (reads): %d bytes", len(group2Content))
 	t.Logf("Group3 (deletes): %d bytes", len(group3Content))
 
-	// Each log should have content (operations were performed)
-	if len(group1Content) > 0 {
-		assert.Contains(t, string(group1Content), "update")
-	}
-	if len(group2Content) > 0 {
-		assert.Contains(t, string(group2Content), "read")
-	}
-	if len(group3Content) > 0 {
-		assert.Contains(t, string(group3Content), "delete")
-	}
+	assert.Contains(t, group1Content, "update")
+	assert.Contains(t, group2Content, "read")
+	assert.Contains(t, group3Content, "delete")
 
-	// Clean up
-	_ = client.Sys().DisableAudit("integration-multigroup-test")
 	_ = client.Sys().Unmount("integration-kv-multigroup")
 }
 
 // TestIntegration_NonMatchingRules verifies unmatched logs aren't captured
 func TestIntegration_NonMatchingRules(t *testing.T) {
-	vaultAddr := getEnvOrDefault("VAULT_ADDR", defaultVaultAddr)
-	vaultToken := getEnvOrDefault("VAULT_TOKEN", defaultVaultToken)
-
 	tmpDir := t.TempDir()
 	logFile := tmpDir + "/nonmatch.log"
 
-	// Rule that should never match normal operations
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	server := newIntegrationAuditServer(t, "udp", []auditserver.RuleGroupConfig{
 		{
-			"name": "impossible_rule",
-			"rules": []string{
+			Name: "impossible_rule",
+			Rules: []string{
 				`Request.Path == "this/path/does/not/exist/ever"`,
 			},
-			"log_file": map[string]interface{}{
-				"file_path":   logFile,
-				"max_size":    10,
-				"max_backups": 1,
-				"max_age":     1,
-				"compress":    false,
-			},
+			LogFile: integrationLogFile(logFile),
 		},
 	})
+	localAddr := startUDPAuditListener(t, server)
 
-	var logBuf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	server, err := auditserver.New(logger)
-	require.NoError(t, err)
+	client := newIntegrationVaultClient(t)
+	enableSocketAudit(t, client, "integration-nonmatch-test", localAddr, "udp", "Integration non-match test")
 
-	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	require.NoError(t, err)
-	conn, err := net.ListenUDP("udp", addr)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	localAddr := conn.LocalAddr().String()
-
-	done := make(chan struct{})
-	go func() {
-		buf := make([]byte, 65535)
-		for {
-			select {
-			case <-done:
-				return
-			default:
-				conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
-				n, _, err := conn.ReadFromUDP(buf)
-				if err != nil {
-					continue
-				}
-				server.React(buf[:n], nil)
-			}
-		}
-	}()
-
-	client, err := vault.NewVaultClient(vaultAddr, vault.TokenAuth{Token: vaultToken})
-	require.NoError(t, err)
-
-	_ = client.Sys().DisableAudit("integration-nonmatch-test")
-
-	err = client.EnableAuditDevice(
-		"integration-nonmatch-test",
-		"socket",
-		"Integration non-match test",
-		map[string]string{
-			"address":     localAddr,
-			"socket_type": "udp",
-			"log_raw":     "false",
-		},
-	)
-	require.NoError(t, err)
-
-	err = client.Sys().Mount("integration-kv-nonmatch", &vaultapi.MountInput{
+	err := client.Sys().Mount("integration-kv-nonmatch", &vaultapi.MountInput{
 		Type:        "kv",
 		Description: "Integration test KV for non-match",
 		Options:     map[string]string{"version": "2"},
@@ -1162,18 +720,10 @@ func TestIntegration_NonMatchingRules(t *testing.T) {
 	_, err = client.Logical().Read("integration-kv-nonmatch/data/test")
 	require.NoError(t, err)
 
-	time.Sleep(500 * time.Millisecond)
-	close(done)
+	require.Never(t, func() bool {
+		return readLogFile(logFile) != ""
+	}, 500*time.Millisecond, 50*time.Millisecond, "Log file should stay empty for non-matching rules")
 
-	// Log file should be empty or not exist
-	logContent, err := os.ReadFile(logFile)
-	if err == nil {
-		assert.Empty(t, logContent, "Log file should be empty for non-matching rules")
-	}
-	// If file doesn't exist, that's also acceptable
-
-	// Clean up
-	_ = client.Sys().DisableAudit("integration-nonmatch-test")
 	_ = client.Sys().Unmount("integration-kv-nonmatch")
 }
 
@@ -1186,85 +736,29 @@ func TestIntegration_AuthFailures(t *testing.T) {
 	deniedLogFile := tmpDir + "/denied.log"
 	allowedLogFile := tmpDir + "/allowed.log"
 
-	// Two rules: one for allowed, one for denied
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	server := newIntegrationAuditServer(t, "udp", []auditserver.RuleGroupConfig{
 		{
-			"name": "denied_operations",
-			"rules": []string{
+			Name: "denied_operations",
+			Rules: []string{
 				`Auth.PolicyResults.Allowed == false`,
 			},
-			"log_file": map[string]interface{}{
-				"file_path":   deniedLogFile,
-				"max_size":    10,
-				"max_backups": 1,
-				"max_age":     1,
-				"compress":    false,
-			},
+			LogFile: integrationLogFile(deniedLogFile),
 		},
 		{
-			"name": "allowed_operations",
-			"rules": []string{
+			Name: "allowed_operations",
+			Rules: []string{
 				`Auth.PolicyResults.Allowed == true`,
 			},
-			"log_file": map[string]interface{}{
-				"file_path":   allowedLogFile,
-				"max_size":    10,
-				"max_backups": 1,
-				"max_age":     1,
-				"compress":    false,
-			},
+			LogFile: integrationLogFile(allowedLogFile),
 		},
 	})
-
-	var logBuf bytes.Buffer
-	logger := slog.New(slog.NewJSONHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	server, err := auditserver.New(logger)
-	require.NoError(t, err)
-
-	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
-	require.NoError(t, err)
-	conn, err := net.ListenUDP("udp", addr)
-	require.NoError(t, err)
-	defer conn.Close()
-
-	localAddr := conn.LocalAddr().String()
-
-	done := make(chan struct{})
-	go func() {
-		buf := make([]byte, 65535)
-		for {
-			select {
-			case <-done:
-				return
-			default:
-				conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
-				n, _, err := conn.ReadFromUDP(buf)
-				if err != nil {
-					continue
-				}
-				server.React(buf[:n], nil)
-			}
-		}
-	}()
+	localAddr := startUDPAuditListener(t, server)
 
 	// Connect as root to setup audit device
 	rootClient, err := vault.NewVaultClient(vaultAddr, vault.TokenAuth{Token: vaultToken})
 	require.NoError(t, err)
 
-	_ = rootClient.Sys().DisableAudit("integration-auth-test")
-
-	err = rootClient.EnableAuditDevice(
-		"integration-auth-test",
-		"socket",
-		"Integration auth test",
-		map[string]string{
-			"address":     localAddr,
-			"socket_type": "udp",
-			"log_raw":     "false",
-		},
-	)
-	require.NoError(t, err)
+	enableSocketAudit(t, rootClient, "integration-auth-test", localAddr, "udp", "Integration auth test")
 
 	// Create a limited policy
 	err = rootClient.Sys().PutPolicy("integration-limited", `
@@ -1307,15 +801,12 @@ func TestIntegration_AuthFailures(t *testing.T) {
 	})
 	assert.Error(t, err, "Should fail due to policy denial")
 
-	time.Sleep(500 * time.Millisecond)
-	close(done)
-
 	// Check allowed log has content
-	allowedContent, _ := os.ReadFile(allowedLogFile)
+	allowedContent := readLogFile(allowedLogFile)
 	t.Logf("Allowed operations log: %d bytes", len(allowedContent))
 
 	// Check denied log - may have content if Vault generates audit for denials
-	deniedContent, _ := os.ReadFile(deniedLogFile)
+	deniedContent := readLogFile(deniedLogFile)
 	t.Logf("Denied operations log: %d bytes", len(deniedContent))
 
 	// Note: Due to UDP delivery timing in dev mode, we may not always receive logs
@@ -1328,7 +819,6 @@ func TestIntegration_AuthFailures(t *testing.T) {
 	}
 
 	// Clean up
-	_ = rootClient.Sys().DisableAudit("integration-auth-test")
 	_ = rootClient.Sys().DeletePolicy("integration-limited")
 	_ = rootClient.Sys().Unmount("integration-kv-auth")
 }

--- a/integration_test.go
+++ b/integration_test.go
@@ -42,7 +42,7 @@ func auditAddressFromListener(listenerAddr net.Addr) string {
 	return net.JoinHostPort(host, port)
 }
 
-func tcpListenerHost() string {
+func auditListenerHost() string {
 	host := getEnvOrDefault("AUDIT_HOST", "127.0.0.1")
 	if host == "127.0.0.1" || host == "localhost" {
 		return host
@@ -86,7 +86,8 @@ func newIntegrationAuditServer(t *testing.T, protocol string, ruleGroups []audit
 
 func startUDPAuditListener(t *testing.T, server *auditserver.AuditServer) string {
 	t.Helper()
-	addr, err := net.ResolveUDPAddr("udp", "127.0.0.1:0")
+	udpListenAddr := net.JoinHostPort(auditListenerHost(), "0")
+	addr, err := net.ResolveUDPAddr("udp", udpListenAddr)
 	require.NoError(t, err)
 
 	conn, err := net.ListenUDP("udp", addr)
@@ -120,7 +121,7 @@ func startUDPAuditListener(t *testing.T, server *auditserver.AuditServer) string
 
 func startTCPAuditListener(t *testing.T, server *auditserver.AuditServer) string {
 	t.Helper()
-	tcpListenAddr := net.JoinHostPort(tcpListenerHost(), "0")
+	tcpListenAddr := net.JoinHostPort(auditListenerHost(), "0")
 	addr, err := net.ResolveTCPAddr("tcp", tcpListenAddr)
 	require.NoError(t, err)
 

--- a/openspec/changes/deepen-audit-architecture-seams/design.md
+++ b/openspec/changes/deepen-audit-architecture-seams/design.md
@@ -1,0 +1,175 @@
+## Context
+
+`vault-audit-filter` receives Vault audit logs over UDP or TCP, evaluates rule expressions, writes matching frames, and optionally forwards or sends messaging side effects. Recent OpenSpec changes added gnet v2 runtime compatibility and TCP audit protocol support. Those changes intentionally preserved behavior and kept `React` as a compatibility shim during migration.
+
+The current implementation is well covered, but some modules are shallow at their public or test-facing interfaces:
+
+- Runtime construction is driven by global Viper state.
+- Rule group execution is represented as exported data fields rather than behavior.
+- Side-effect queue, durable retry, and dead-letter details leak into tests.
+- Transport framing shares a module with audit frame processing.
+- Vault socket audit setup exposes map keys that callers must remember.
+- Integration tests repeat orchestration logic and timing assumptions.
+
+## Goals
+
+- Preserve existing behavior while changing internal module shape.
+- Concentrate configuration defaults, validation, and normalization in one place.
+- Give audit frame processing a smaller interface for rule group execution and side-effect submission.
+- Keep gnet, UDP, and TCP framing details out of filtering logic.
+- Keep Vault socket audit-device schema knowledge inside the Vault package.
+- Reduce repeated integration setup and waiting logic.
+- Maintain or improve current package coverage for changed files.
+
+## Non-Goals
+
+- Do not change rule expression syntax or matching semantics.
+- Do not change default async behavior, including latency-first drop mode.
+- Do not introduce a new durable queue technology.
+- Do not change user-facing config keys unless a compatibility adapter preserves existing keys.
+- Do not remove `React` until the existing OnTraffic parity follow-up is satisfied.
+- Do not introduce new dependencies unless a later implementation task justifies one explicitly.
+
+## Decisions
+
+### 1. Use One Umbrella Change With Staged Tasks
+
+The candidates overlap around `auditserver.New`, rule group construction, and tests. A single OpenSpec change avoids duplicated requirements and lets implementation proceed in safe stages. Each stage should be independently verifiable.
+
+### 2. Make Config Assembly the First Stage
+
+The first deepening should be a typed configuration assembly module. Viper should remain an adapter in command startup and tests that intentionally exercise CLI/config behavior. Runtime modules should receive normalized settings rather than reading global state.
+
+This stage unlocks the later work by giving tests and constructors explicit inputs.
+
+### 3. Preserve Existing Runtime Behavior as the Compatibility Target
+
+The goal is module depth, locality, and leverage, not behavior change. Existing behavior around matched/unmatched frames, invalid JSON, log writes, forwarding, messaging, drop counts, durable retry, and Vault setup should be regression-tested before and after each implementation stage.
+
+### 4. Keep Consumer-Owned Interfaces at Real Seams
+
+Interfaces should live where behavior varies for the consuming module. For example, auditserver may consume a small side-effect submission interface, while concrete Slack, webhook, UDP, and file-store adapters remain behind construction or package-specific seams. One adapter does not justify broad interface surface unless tests or runtime behavior truly vary across it.
+
+### 5. Coordinate Transport Work With the Existing React Follow-Up
+
+The archived gnet v2 migration explicitly kept `React` as a temporary compatibility shim. This change may create a transport framing module, but it must not remove `React` until the OnTraffic parity migration has been implemented and verified.
+
+## Module Plan
+
+### Configuration Assembly
+
+Create a module that owns:
+
+- async defaults and validation
+- durable retry defaults and validation
+- audit protocol normalization
+- rule group config decoding
+- log file config normalization
+- side-effect adapter construction inputs
+
+Command code remains the Viper adapter. Tests that do not exercise Viper should construct typed settings directly.
+
+### Vault Socket Audit Device
+
+Add a typed socket audit-device specification for common setup:
+
+- path
+- address
+- protocol
+- description
+- raw logging policy
+
+The Vault package should translate that typed specification to Vault's option map. Existing generic `EnableAuditDevice` can remain for lower-level callers if needed.
+
+### Rule Group Execution
+
+Move rule group behavior behind a deeper module:
+
+- rule matching
+- log writing and fallback logger behavior
+- payload copy/string preparation
+- side-effect request creation
+
+The frame processor should not reason about nil combinations across writer, logger, messenger, and forwarder fields.
+
+### Side-Effect Processor
+
+Create a higher-level module for side effects:
+
+- submit side-effect request
+- queue capacity and drop accounting
+- wait/drop enqueue mode
+- durable save and replay
+- retry and dead-letter transitions
+- worker lifecycle
+
+File-backed durable storage should remain an adapter behind this module. Tests should be able to exercise retry and store behavior without constructing `AuditServer` internals.
+
+### Transport Framing
+
+Separate gnet and framing concerns from filtering:
+
+- gnet `OnTraffic` adapter
+- UDP one-frame reads
+- TCP newline-delimited stream buffering
+- connection context carryover
+- conversion of processing outcomes to gnet actions
+
+The audit frame processor remains focused on parse, match, log, and side-effect submission. `React` remains until the existing parity follow-up allows removal.
+
+### Integration Harness
+
+Consolidate repeated integration helper logic:
+
+- environment defaults
+- Vault client creation
+- audit device setup and cleanup
+- UDP/TCP audit listener setup
+- frame delivery into the runtime entry path
+- wait/poll assertions instead of fixed sleeps where practical
+- log file and forwarding assertions
+
+This harness should stay unexported and test-only.
+
+## Data Flow
+
+1. Command startup reads flags/config through Viper.
+2. Config assembly normalizes settings and constructs typed runtime inputs.
+3. The audit server is constructed from explicit settings and adapters.
+4. Transport adapter receives network bytes and emits complete audit frames.
+5. Audit frame processor decodes and evaluates frames.
+6. Rule group execution writes logs and creates side-effect requests.
+7. Side-effect processor handles async delivery, drops, durable retry, and dead letters.
+
+## Error Handling
+
+- Invalid user configuration should fail in config assembly with contextual errors.
+- Invalid audit protocol should keep current command-level failure behavior.
+- Invalid audit frames should preserve current parse-error action behavior.
+- Rule compilation failures should preserve current logging and skip behavior unless a later task deliberately changes it.
+- Side-effect delivery failures should preserve current logging, retry, and dead-letter behavior.
+- Vault setup errors should keep contextual wrapping.
+
+## Testing
+
+Each stage should include focused regression coverage before broad verification.
+
+Required final verification:
+
+- `go fmt ./...`
+- `go vet ./...`
+- `go test -v -race ./...`
+- `go test ./... -coverpkg=./... -coverprofile=coverage.out`
+- `go tool cover -func=coverage.out`
+
+If integration-related code changes, also run:
+
+- `go test -tags=integration -v -race ./...`
+
+## Risks and Mitigations
+
+- **Risk: broad refactor changes behavior accidentally.** Mitigation: stage the work and preserve existing tests as regression gates.
+- **Risk: new seams become hypothetical.** Mitigation: keep interfaces consumer-owned and require at least runtime/test variation before broadening an interface.
+- **Risk: transport work conflicts with the existing React migration.** Mitigation: keep `React` until OnTraffic parity is verified.
+- **Risk: config assembly becomes a new shallow pass-through.** Mitigation: put defaults, validation, normalization, and typed settings construction behind the module, not just field copying.
+- **Risk: integration harness hides important scenario detail.** Mitigation: keep scenario inputs explicit and centralize only repeated orchestration.

--- a/openspec/changes/deepen-audit-architecture-seams/proposal.md
+++ b/openspec/changes/deepen-audit-architecture-seams/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The architecture review found several related seams where implementation knowledge leaks across the audit filter:
+
+- `auditserver.New(logger)` depends on hidden global Viper state while constructing rules, log writers, messaging, forwarding, async settings, durable retry, and transport policy.
+- `RuleGroup` exposes a field bag whose nil combinations are interpreted by frame handling code.
+- Async side-effect behavior is meaningful, but its queue, store, retry, and timer details are tested and called through low-level internals.
+- gnet/TCP/UDP framing sits in the same module as audit filtering behavior.
+- Vault socket audit setup leaks raw option-map keys into commands and integration tests.
+- Integration tests repeat Vault, listener, wait, and assertion wiring.
+
+These are not separate cleanups. They overlap around startup construction, audit frame processing, and test harnesses. Treating them as one staged architecture change keeps behavior stable while improving locality and leverage.
+
+## What Changes
+
+- Add an explicit configuration assembly module that reads Viper in command code and passes normalized typed settings into runtime modules.
+- Deepen rule group execution so matching, log writing, payload preparation, and side-effect request creation live behind one rule group seam.
+- Raise the side-effect processor seam so queue mode, drops, wait behavior, durable persistence, retry, and dead-letter handling are owned by one module.
+- Separate transport framing from audit filtering so gnet callback shape, UDP frames, and TCP line buffering sit behind a transport adapter.
+- Type Vault socket audit-device setup so callers do not construct raw Vault option maps for common socket audit devices.
+- Consolidate integration harness helpers for Vault setup, audit listeners, frame entry, waits, cleanup, and assertions.
+
+## Capabilities
+
+### New Capabilities
+
+- `audit-architecture-seams`: Define the requirements for deeper module seams around configuration assembly, audit filtering, side effects, transport framing, Vault audit-device setup, and integration harnesses.
+
+### Modified Capabilities
+
+- None. This change should preserve existing behavior while reshaping internal interfaces.
+
+## Impact
+
+- Affected code: `cmd/`, `pkg/auditserver/`, `pkg/forwarder/`, `pkg/messaging/`, `pkg/vault/`, and `integration_test.go`.
+- Runtime behavior: intended to remain unchanged for UDP/TCP intake, rule matching, logging, forwarding, messaging, async drops, durable retry, and Vault setup payloads.
+- Test behavior: tests should move toward explicit module interfaces instead of global Viper state and private field mutation.
+- OpenSpec coordination: this change must respect the archived gnet v2 migration decisions and the existing follow-up to migrate `React`-based tests to `OnTraffic`.

--- a/openspec/changes/deepen-audit-architecture-seams/specs/audit-architecture-seams/spec.md
+++ b/openspec/changes/deepen-audit-architecture-seams/specs/audit-architecture-seams/spec.md
@@ -1,0 +1,135 @@
+## ADDED Requirements
+
+### Requirement: Explicit configuration assembly
+
+The system SHALL assemble runtime configuration through a typed configuration module before constructing audit runtime modules.
+
+#### Scenario: Runtime construction avoids global Viper
+
+- **WHEN** audit server runtime modules are constructed outside command/config adapter tests
+- **THEN** they SHALL receive typed settings rather than reading global Viper state
+
+#### Scenario: Defaults and validation are centralized
+
+- **WHEN** async, durable retry, or audit protocol settings are omitted or invalid
+- **THEN** defaulting and validation SHALL occur in one configuration assembly path with contextual errors or documented fallbacks
+
+#### Scenario: Existing configuration remains compatible
+
+- **WHEN** users provide existing config keys such as `rule_groups`, `async.queue_size`, `async.workers`, or `vault.audit_protocol`
+- **THEN** those keys SHALL continue to map to equivalent runtime behavior
+
+### Requirement: Typed Vault socket audit-device setup
+
+The system SHALL provide a typed path for standard Vault socket audit-device setup.
+
+#### Scenario: Setup command enables socket audit
+
+- **WHEN** the setup command enables a Vault socket audit device
+- **THEN** command code SHALL pass a typed socket audit-device specification rather than manually constructing Vault socket option maps
+
+#### Scenario: Vault option map creation is localized
+
+- **WHEN** Vault socket audit options are sent to Vault
+- **THEN** Vault socket keys such as `address`, `socket_type`, and `log_raw` SHALL be produced inside the Vault package or its adapter module
+
+#### Scenario: Existing generic audit enablement remains available
+
+- **WHEN** lower-level callers need non-socket or custom audit device setup
+- **THEN** the existing generic enablement path MAY remain available with current behavior
+
+### Requirement: Deep rule group execution seam
+
+The system SHALL concentrate rule group matching, log writing, payload preparation, and side-effect request creation behind a rule group execution module.
+
+#### Scenario: Frame processing evaluates groups
+
+- **WHEN** a decoded audit frame is processed
+- **THEN** frame processing SHALL not need to inspect writer, logger, messenger, or forwarder nil combinations directly
+
+#### Scenario: Empty rules preserve match-all behavior
+
+- **WHEN** a rule group has no compiled rules
+- **THEN** that group SHALL match audit frames as it does today
+
+#### Scenario: Rule runtime errors preserve skip behavior
+
+- **WHEN** a compiled rule returns an evaluation error
+- **THEN** evaluation SHALL continue to preserve existing skip/non-match behavior
+
+#### Scenario: Log write behavior remains stable
+
+- **WHEN** a matched rule group has a writer, logger fallback, or write error
+- **THEN** log writing and error logging SHALL preserve existing behavior
+
+### Requirement: Side-effect processor seam
+
+The system SHALL own async side-effect delivery through a side-effect processor module with a higher-level submit interface.
+
+#### Scenario: Drop mode stays non-blocking
+
+- **WHEN** side-effect enqueue mode is drop and the queue is full
+- **THEN** submission SHALL preserve current non-blocking drop behavior and drop accounting
+
+#### Scenario: Wait mode respects timeout
+
+- **WHEN** side-effect enqueue mode is wait and the queue remains full
+- **THEN** submission SHALL wait up to the configured timeout and then preserve current drop or durable retry behavior
+
+#### Scenario: Durable retry behavior remains stable
+
+- **WHEN** durable side effects are enabled and delivery fails
+- **THEN** persistence, replay, retry, max-attempt, and dead-letter behavior SHALL remain equivalent to current behavior
+
+#### Scenario: Side-effect adapters remain substitutable
+
+- **WHEN** messaging or forwarding behavior is tested
+- **THEN** tests SHALL be able to substitute adapters without mutating unrelated audit server internals
+
+### Requirement: Transport framing seam
+
+The system SHALL separate network transport framing from audit frame filtering behavior.
+
+#### Scenario: UDP frame delivery
+
+- **WHEN** UDP traffic is received
+- **THEN** the transport adapter SHALL deliver the datagram payload as one audit frame with current behavior
+
+#### Scenario: TCP stream delivery
+
+- **WHEN** TCP traffic is received with multiple complete newline-delimited records or split records
+- **THEN** the transport adapter SHALL preserve current line buffering and carryover behavior
+
+#### Scenario: Action outcomes remain compatible
+
+- **WHEN** audit frame processing sees invalid JSON, no matching rule group, or at least one matching rule group
+- **THEN** returned gnet action outcomes SHALL preserve current behavior
+
+#### Scenario: React compatibility follows existing migration
+
+- **WHEN** transport framing is refactored
+- **THEN** `React` SHALL remain available until the existing OnTraffic parity migration verifies removal criteria
+
+### Requirement: Integration harness locality
+
+The integration suite SHALL concentrate repeated Vault, listener, wait, cleanup, and assertion orchestration in unexported test helpers.
+
+#### Scenario: Vault audit integration setup
+
+- **WHEN** an integration test needs Vault client setup and audit-device lifecycle management
+- **THEN** it SHALL use shared helper logic for repeated setup and cleanup
+
+#### Scenario: Listener and frame delivery setup
+
+- **WHEN** an integration test needs UDP or TCP audit delivery
+- **THEN** it SHALL use shared listener and frame-delivery helpers while keeping scenario-specific inputs explicit
+
+#### Scenario: Waiting for async effects
+
+- **WHEN** an integration test waits for logs or forwarding side effects
+- **THEN** it SHOULD use polling helpers instead of fixed sleeps where practical
+
+#### Scenario: Integration tests remain guarded
+
+- **WHEN** integration harness code is added or changed
+- **THEN** integration tests SHALL remain guarded by `//go:build integration`

--- a/openspec/changes/deepen-audit-architecture-seams/tasks.md
+++ b/openspec/changes/deepen-audit-architecture-seams/tasks.md
@@ -1,0 +1,61 @@
+## 1. Baseline and Guardrails
+
+- [x] 1.1 Run baseline `go test -v -race ./...`.
+- [x] 1.2 Run baseline `go test ./... -coverpkg=./... -coverprofile=coverage.out` and `go tool cover -func=coverage.out`.
+- [x] 1.3 Capture focused behavior checks for invalid JSON, no-match frames, matched frames, log writing, forwarding, messaging, async drops, durable retry, TCP framing, and Vault setup payloads.
+- [x] 1.4 Confirm the existing OnTraffic parity follow-up remains the owner of `React` shim removal.
+
+## 2. Configuration Assembly
+
+- [x] 2.1 Introduce typed runtime settings for audit server construction.
+- [x] 2.2 Move async defaults and validation into config assembly.
+- [x] 2.3 Move durable retry defaults and validation into config assembly.
+- [x] 2.4 Move audit protocol normalization into one config path used by command startup and audit server construction.
+- [x] 2.5 Keep Viper usage in command/config adapter code and remove runtime reads from `pkg/auditserver`.
+- [x] 2.6 Update unit tests to construct typed settings directly where Viper behavior is not under test.
+
+## 3. Vault Socket Audit Device
+
+- [x] 3.1 Add a typed Vault socket audit-device specification.
+- [x] 3.2 Translate the typed specification to Vault socket audit options inside `pkg/vault`.
+- [x] 3.3 Update setup command code to use the typed socket audit-device path.
+- [x] 3.4 Update integration tests to avoid constructing raw socket audit option maps where they exercise standard socket audit setup.
+
+## 4. Rule Group Execution
+
+- [x] 4.1 Introduce a rule group execution module that owns match, write, payload preparation, and side-effect request creation.
+- [x] 4.2 Reduce frame handler knowledge of rule group internals and nil field combinations.
+- [x] 4.3 Preserve existing behavior for empty rules, runtime rule errors, invalid compiled rules, writer errors, and logger fallback.
+- [x] 4.4 Update tests to exercise rule group execution through its interface.
+
+## 5. Side-Effect Processor
+
+- [x] 5.1 Introduce a side-effect processor module with a higher-level submit interface.
+- [x] 5.2 Move queue mode, wait/drop behavior, drop accounting, and worker lifecycle behind the processor.
+- [x] 5.3 Keep file-backed durable storage as an adapter behind the processor.
+- [x] 5.4 Preserve durable save, replay, retry, and dead-letter behavior.
+- [x] 5.5 Update tests to avoid constructing `AuditServer` solely to test side-effect queue internals.
+
+## 6. Transport Framing
+
+- [x] 6.1 Introduce a transport adapter module for gnet callback and frame extraction.
+- [x] 6.2 Move UDP one-frame and TCP newline-delimited buffering behavior behind the transport adapter.
+- [x] 6.3 Preserve existing parse-error, no-match, and match action outcomes.
+- [x] 6.4 Keep `React` compatibility until the OnTraffic parity migration has passed.
+- [x] 6.5 Update tests to share frame-processing fixtures with the existing OnTraffic parity follow-up where practical.
+
+## 7. Integration Harness
+
+- [x] 7.1 Create unexported integration helpers for Vault client setup, audit device setup/cleanup, UDP/TCP listeners, and frame delivery.
+- [x] 7.2 Replace repeated fixed sleeps with polling helpers where practical.
+- [x] 7.3 Consolidate repeated log file, forwarding, and operation filtering assertions without hiding scenario-specific inputs.
+- [x] 7.4 Ensure integration tests remain guarded by `//go:build integration`.
+
+## 8. Documentation and Verification
+
+- [x] 8.1 Update README configuration docs if constructor/config assembly changes alter documented defaults or examples.
+- [x] 8.2 Run `go fmt ./...`.
+- [x] 8.3 Run `go vet ./...`.
+- [x] 8.4 Run `go test -v -race ./...`.
+- [x] 8.5 Run coverage commands and close misses/partials in changed packages.
+- [x] 8.6 If integration paths changed, run `go test -tags=integration -v -race ./...`.

--- a/pkg/auditserver/async.go
+++ b/pkg/auditserver/async.go
@@ -1,7 +1,9 @@
 package auditserver
 
 import (
+	"log/slog"
 	"strconv"
+	"sync/atomic"
 	"time"
 
 	"github.com/ncode/vault-audit-filter/pkg/forwarder"
@@ -20,125 +22,227 @@ type sideTask struct {
 	forwarder  forwarder.Forwarder
 }
 
-func (as *AuditServer) enqueueSide(task sideTask) bool {
-	if as.asyncDurableEnabled && as.sideStore != nil {
+type sideEffectProcessorConfig struct {
+	logger               *slog.Logger
+	queueSize            int
+	enqueueMode          string
+	enqueueTimeout       time.Duration
+	durableEnabled       bool
+	retryMaxAttempts     int
+	retryBackoff         time.Duration
+	store                sideTaskStore
+	adapterResolver      sideTaskAdapterResolver
+	mirrorDrops          *atomic.Uint64
+	mirrorTaskSeq        *atomic.Uint64
+	mirrorQueue          *chan sideTask
+	mirrorEnqueueMode    *string
+	mirrorEnqueueTimeout *time.Duration
+}
+
+type sideTaskAdapters struct {
+	messenger messaging.Messenger
+	forwarder forwarder.Forwarder
+}
+
+type sideTaskAdapterResolver func(groupName string) sideTaskAdapters
+
+type sideEffectProcessor struct {
+	logger           *slog.Logger
+	queue            chan sideTask
+	drops            atomic.Uint64
+	taskSeq          atomic.Uint64
+	enqueueMode      string
+	enqueueTimeout   time.Duration
+	durableEnabled   bool
+	retryMaxAttempts int
+	retryBackoff     time.Duration
+	store            sideTaskStore
+	adapterResolver  sideTaskAdapterResolver
+	mirrorDrops      *atomic.Uint64
+	mirrorTaskSeq    *atomic.Uint64
+}
+
+func newSideEffectProcessor(config sideEffectProcessorConfig) *sideEffectProcessor {
+	queueSize := config.queueSize
+	if queueSize <= 0 {
+		queueSize = defaultAsyncQueueSize
+	}
+	processor := &sideEffectProcessor{
+		logger:           config.logger,
+		queue:            make(chan sideTask, queueSize),
+		enqueueMode:      config.enqueueMode,
+		enqueueTimeout:   config.enqueueTimeout,
+		durableEnabled:   config.durableEnabled,
+		retryMaxAttempts: config.retryMaxAttempts,
+		retryBackoff:     config.retryBackoff,
+		store:            config.store,
+		adapterResolver:  config.adapterResolver,
+		mirrorDrops:      config.mirrorDrops,
+		mirrorTaskSeq:    config.mirrorTaskSeq,
+	}
+	if config.mirrorQueue != nil {
+		*config.mirrorQueue = processor.queue
+	}
+	if config.mirrorEnqueueMode != nil {
+		*config.mirrorEnqueueMode = processor.enqueueMode
+	}
+	if config.mirrorEnqueueTimeout != nil {
+		*config.mirrorEnqueueTimeout = processor.enqueueTimeout
+	}
+	return processor
+}
+
+func (p *sideEffectProcessor) Submit(req sideEffectRequest) bool {
+	return p.enqueue(sideTask{
+		groupName:  req.groupName,
+		payload:    req.payload,
+		payloadStr: req.payloadStr,
+		messenger:  req.messenger,
+		forwarder:  req.forwarder,
+	})
+}
+
+func (p *sideEffectProcessor) enqueue(task sideTask) bool {
+	if p.durableEnabled && p.store != nil {
 		if task.id == "" {
-			task.id = as.nextSideTaskID()
+			task.id = p.nextTaskID()
 		}
-		if err := as.sideStore.Save(task); err != nil {
-			as.logger.Error("Failed to persist durable side task", "error", err)
+		if err := p.store.Save(task); err != nil {
+			if p.logger != nil {
+				p.logger.Error("Failed to persist durable side task", "error", err)
+			}
 			return false
 		}
 	}
 
-	if as.asyncEnqueueMode == "wait" {
-		timeout := as.asyncEnqueueTimeout
+	if p.enqueueMode == "wait" {
+		timeout := p.enqueueTimeout
 		if timeout <= 0 {
 			timeout = 5 * time.Millisecond
 		}
 		timer := time.NewTimer(timeout)
 		defer timer.Stop()
 		select {
-		case as.sideQueue <- task:
+		case p.queue <- task:
 			return true
 		case <-timer.C:
-			if as.asyncDurableEnabled {
-				time.AfterFunc(as.asyncRetryBackoff, func() {
-					_ = as.enqueueSide(task)
+			if p.durableEnabled {
+				time.AfterFunc(p.retryBackoff, func() {
+					_ = p.enqueue(task)
 				})
 				return true
 			}
-			as.sideDrops.Add(1)
+			p.addDrop()
 			return false
 		}
 	}
 
 	select {
-	case as.sideQueue <- task:
+	case p.queue <- task:
 		return true
 	default:
-		if as.asyncDurableEnabled {
-			time.AfterFunc(as.asyncRetryBackoff, func() {
-				_ = as.enqueueSide(task)
+		if p.durableEnabled {
+			time.AfterFunc(p.retryBackoff, func() {
+				_ = p.enqueue(task)
 			})
 			return true
 		}
-		as.sideDrops.Add(1)
+		p.addDrop()
 		return false
 	}
 }
 
-func (as *AuditServer) nextSideTaskID() string {
-	n := as.sideTaskSeq.Add(1)
+func (p *sideEffectProcessor) nextTaskID() string {
+	var n uint64
+	if p.mirrorTaskSeq != nil {
+		n = p.mirrorTaskSeq.Add(1)
+	} else {
+		n = p.taskSeq.Add(1)
+	}
 	return time.Now().Format("20060102150405.000000000") + "-" + strconv.FormatUint(n, 10)
 }
 
-func (as *AuditServer) startSideWorkers(n int) {
+func (p *sideEffectProcessor) startWorkers(n int) {
 	if n <= 0 {
 		return
 	}
 	for i := 0; i < n; i++ {
 		go func() {
-			for task := range as.sideQueue {
-				as.processSideTask(task)
+			for task := range p.queue {
+				p.process(task)
 			}
 		}()
 	}
 }
 
-func (as *AuditServer) processSideTask(task sideTask) {
+func (p *sideEffectProcessor) process(task sideTask) {
 	messenger := task.messenger
 	fwd := task.forwarder
-	if task.groupName != "" {
-		for i := range as.ruleGroups {
-			if as.ruleGroups[i].Name == task.groupName {
-				if messenger == nil {
-					messenger = as.ruleGroups[i].Messenger
-				}
-				if fwd == nil {
-					fwd = as.ruleGroups[i].Forwarder
-				}
-				break
-			}
+	if task.groupName != "" && p.adapterResolver != nil {
+		adapters := p.adapterResolver(task.groupName)
+		if messenger == nil {
+			messenger = adapters.messenger
+		}
+		if fwd == nil {
+			fwd = adapters.forwarder
 		}
 	}
 
 	var sendErr error
 	if messenger != nil {
 		if err := messenger.Send(task.payloadStr); err != nil {
-			as.logger.Error("Failed to send notification", "error", err)
+			if p.logger != nil {
+				p.logger.Error("Failed to send notification", "error", err)
+			}
 			sendErr = err
 		}
 	}
 	if fwd != nil {
 		if err := fwd.Forward(task.payload); err != nil {
-			as.logger.Error("Failed to forward message", "error", err)
+			if p.logger != nil {
+				p.logger.Error("Failed to forward message", "error", err)
+			}
 			if sendErr == nil {
 				sendErr = err
 			}
 		}
 	}
 
-	if !as.asyncDurableEnabled || as.sideStore == nil || task.id == "" {
+	if !p.durableEnabled || p.store == nil || task.id == "" {
 		return
 	}
 
 	if sendErr == nil {
-		_ = as.sideStore.Delete(task.id)
+		_ = p.store.Delete(task.id)
 		return
 	}
 
 	task.attempts++
-	if task.attempts >= as.asyncRetryMaxAttempts {
-		_ = as.sideStore.MoveToDeadLetter(task, sendErr.Error())
-		_ = as.sideStore.Delete(task.id)
+	if task.attempts >= p.retryMaxAttempts {
+		_ = p.store.MoveToDeadLetter(task, sendErr.Error())
+		_ = p.store.Delete(task.id)
 		return
 	}
 
-	if err := as.sideStore.Save(task); err != nil {
-		as.logger.Error("Failed to save retry side task", "error", err)
+	if err := p.store.Save(task); err != nil && p.logger != nil {
+		p.logger.Error("Failed to save retry side task", "error", err)
 	}
-	time.AfterFunc(as.asyncRetryBackoff, func() {
-		_ = as.enqueueSide(task)
+	time.AfterFunc(p.retryBackoff, func() {
+		_ = p.enqueue(task)
 	})
+}
+
+func (p *sideEffectProcessor) Drops() uint64 {
+	if p.mirrorDrops != nil {
+		return p.mirrorDrops.Load()
+	}
+	return p.drops.Load()
+}
+
+func (p *sideEffectProcessor) addDrop() {
+	if p.mirrorDrops != nil {
+		p.mirrorDrops.Add(1)
+		return
+	}
+	p.drops.Add(1)
 }

--- a/pkg/auditserver/bench_test.go
+++ b/pkg/auditserver/bench_test.go
@@ -6,23 +6,18 @@ import (
 	"testing"
 
 	"github.com/expr-lang/expr"
-	"github.com/spf13/viper"
 )
 
 func BenchmarkReact(b *testing.B) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	settings := testRuntimeSettings([]RuleGroupConfig{
 		{
-			"name":  "rg",
-			"rules": []string{"true"},
-			"log_file": map[string]interface{}{
-				"file_path": "/tmp/test.log",
-				"max_size":  1,
-			},
+			Name:    "rg",
+			Rules:   []string{"true"},
+			LogFile: LogFileConfig{FilePath: "/tmp/test.log", MaxSize: 1},
 		},
 	})
-	server, _ := New(logger)
+	server, _ := New(logger, settings)
 	frame := []byte(`{"type":"request","time":"2000-01-01T00:00:00Z","auth":{},"request":{},"response":{}}`)
 	b.ReportAllocs()
 	b.ResetTimer()
@@ -33,18 +28,14 @@ func BenchmarkReact(b *testing.B) {
 
 func BenchmarkMatchFrame(b *testing.B) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo}))
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	settings := testRuntimeSettings([]RuleGroupConfig{
 		{
-			"name":  "rg",
-			"rules": []string{"Auth.PolicyResults.Allowed == true"},
-			"log_file": map[string]interface{}{
-				"file_path": "/tmp/test.log",
-				"max_size":  1,
-			},
+			Name:    "rg",
+			Rules:   []string{"Auth.PolicyResults.Allowed == true"},
+			LogFile: LogFileConfig{FilePath: "/tmp/test.log", MaxSize: 1},
 		},
 	})
-	server, _ := New(logger)
+	server, _ := New(logger, settings)
 	frame := []byte(`{"type":"request","time":"2000-01-01T00:00:00Z","auth":{"policy_results":{"allowed":true}},"request":{},"response":{}}`)
 	b.ReportAllocs()
 	b.ResetTimer()

--- a/pkg/auditserver/config.go
+++ b/pkg/auditserver/config.go
@@ -1,0 +1,130 @@
+package auditserver
+
+import (
+	"log/slog"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAsyncQueueSize      = 20
+	defaultAsyncEnqueueMode    = "drop"
+	defaultAsyncEnqueueTimeout = 5 * time.Millisecond
+	defaultAsyncTimeout        = 5 * time.Second
+	defaultDurableDir          = "./.vault-audit-filter-sideeffects"
+	defaultRetryMaxAttempts    = 3
+	defaultRetryBackoff        = 100 * time.Millisecond
+	defaultAuditProtocol       = "udp"
+)
+
+type RuntimeSettings struct {
+	RuleGroups    []RuleGroupConfig
+	Async         AsyncSettings
+	AuditProtocol string
+}
+
+type AsyncSettings struct {
+	QueueSize      int
+	Workers        int
+	EnqueueMode    string
+	EnqueueTimeout time.Duration
+	Timeout        time.Duration
+	Durable        DurableSettings
+	Retry          RetrySettings
+}
+
+type DurableSettings struct {
+	Enabled bool
+	Dir     string
+}
+
+type RetrySettings struct {
+	MaxAttempts int
+	Backoff     time.Duration
+}
+
+func DefaultRuntimeSettings() RuntimeSettings {
+	return RuntimeSettings{
+		AuditProtocol: defaultAuditProtocol,
+		Async: AsyncSettings{
+			QueueSize:      defaultAsyncQueueSize,
+			Workers:        defaultSideWorkers,
+			EnqueueMode:    defaultAsyncEnqueueMode,
+			EnqueueTimeout: defaultAsyncEnqueueTimeout,
+			Timeout:        defaultAsyncTimeout,
+			Durable: DurableSettings{
+				Enabled: false,
+				Dir:     defaultDurableDir,
+			},
+			Retry: RetrySettings{
+				MaxAttempts: defaultRetryMaxAttempts,
+				Backoff:     defaultRetryBackoff,
+			},
+		},
+	}
+}
+
+func NormalizeRuntimeSettings(settings RuntimeSettings, logger *slog.Logger) RuntimeSettings {
+	defaults := DefaultRuntimeSettings()
+
+	protocol := strings.ToLower(strings.TrimSpace(settings.AuditProtocol))
+	switch protocol {
+	case "":
+		settings.AuditProtocol = defaults.AuditProtocol
+	case "udp", "tcp":
+		settings.AuditProtocol = protocol
+	default:
+		warnConfigFallback(logger, "Invalid vault.audit_protocol; using udp", "value", protocol)
+		settings.AuditProtocol = defaults.AuditProtocol
+	}
+
+	if settings.Async.QueueSize <= 0 {
+		settings.Async.QueueSize = defaults.Async.QueueSize
+	}
+	if settings.Async.Workers < 0 {
+		settings.Async.Workers = defaults.Async.Workers
+	}
+
+	enqueueMode := strings.ToLower(strings.TrimSpace(settings.Async.EnqueueMode))
+	switch enqueueMode {
+	case "":
+		settings.Async.EnqueueMode = defaults.Async.EnqueueMode
+	case "drop", "wait":
+		settings.Async.EnqueueMode = enqueueMode
+	default:
+		warnConfigFallback(logger, "Invalid async.enqueue_mode; using default", "value", enqueueMode)
+		settings.Async.EnqueueMode = defaults.Async.EnqueueMode
+	}
+
+	if settings.Async.EnqueueTimeout <= 0 {
+		warnConfigFallback(logger, "Invalid async.enqueue_timeout; using default", "value", settings.Async.EnqueueTimeout.String())
+		settings.Async.EnqueueTimeout = defaults.Async.EnqueueTimeout
+	}
+	if settings.Async.Timeout <= 0 {
+		warnConfigFallback(logger, "Invalid async.timeout; using default", "value", settings.Async.Timeout.String())
+		settings.Async.Timeout = defaults.Async.Timeout
+	}
+
+	durableDir := strings.TrimSpace(settings.Async.Durable.Dir)
+	if durableDir == "" {
+		settings.Async.Durable.Dir = defaults.Async.Durable.Dir
+	} else {
+		settings.Async.Durable.Dir = durableDir
+	}
+
+	if settings.Async.Retry.MaxAttempts <= 0 {
+		settings.Async.Retry.MaxAttempts = defaults.Async.Retry.MaxAttempts
+	}
+	if settings.Async.Retry.Backoff <= 0 {
+		warnConfigFallback(logger, "Invalid async.retry.backoff; using default", "value", settings.Async.Retry.Backoff.String())
+		settings.Async.Retry.Backoff = defaults.Async.Retry.Backoff
+	}
+
+	return settings
+}
+
+func warnConfigFallback(logger *slog.Logger, msg string, args ...any) {
+	if logger != nil {
+		logger.Warn(msg, args...)
+	}
+}

--- a/pkg/auditserver/durable.go
+++ b/pkg/auditserver/durable.go
@@ -148,16 +148,18 @@ func (s *fileSideTaskStore) Pending() ([]sideTask, error) {
 	return tasks, nil
 }
 
-func (as *AuditServer) replayDurablePending() {
-	if as.sideStore == nil {
+func (p *sideEffectProcessor) replayDurablePending() {
+	if p.store == nil {
 		return
 	}
-	tasks, err := as.sideStore.Pending()
+	tasks, err := p.store.Pending()
 	if err != nil {
-		as.logger.Error("Failed to load durable pending tasks", "error", err)
+		if p.logger != nil {
+			p.logger.Error("Failed to load durable pending tasks", "error", err)
+		}
 		return
 	}
 	for _, task := range tasks {
-		_ = as.enqueueSide(task)
+		_ = p.enqueue(task)
 	}
 }

--- a/pkg/auditserver/rule_group.go
+++ b/pkg/auditserver/rule_group.go
@@ -1,0 +1,128 @@
+package auditserver
+
+import (
+	"log/slog"
+
+	"github.com/expr-lang/expr"
+	"github.com/ncode/vault-audit-filter/pkg/forwarder"
+	"github.com/ncode/vault-audit-filter/pkg/messaging"
+)
+
+type sideEffectRequest struct {
+	groupName  string
+	payload    []byte
+	payloadStr string
+	messenger  messaging.Messenger
+	forwarder  forwarder.Forwarder
+}
+
+type sideEffectSubmitter interface {
+	submitSideEffect(sideEffectRequest) bool
+}
+
+type ruleGroupExecutor struct {
+	groups    []RuleGroup
+	logger    *slog.Logger
+	submitter sideEffectSubmitter
+}
+
+type ruleGroupPayload struct {
+	frame           []byte
+	payload         []byte
+	payloadStr      string
+	payloadReady    bool
+	payloadStrReady bool
+}
+
+func newRuleGroupExecutor(groups []RuleGroup, logger *slog.Logger, submitter sideEffectSubmitter) ruleGroupExecutor {
+	return ruleGroupExecutor{
+		groups:    groups,
+		logger:    logger,
+		submitter: submitter,
+	}
+}
+
+func (e ruleGroupExecutor) Match(auditLog *AuditLog) []int {
+	var matchedIndexes []int
+	for idx := range e.groups {
+		if e.groups[idx].shouldLog(auditLog) {
+			matchedIndexes = append(matchedIndexes, idx)
+		}
+	}
+	return matchedIndexes
+}
+
+func (e ruleGroupExecutor) Execute(frame []byte, matchedIndexes []int) {
+	payload := ruleGroupPayload{frame: frame}
+	for _, idx := range matchedIndexes {
+		if idx < 0 || idx >= len(e.groups) {
+			continue
+		}
+		e.executeGroup(&e.groups[idx], &payload)
+	}
+}
+
+func (e ruleGroupExecutor) executeGroup(rg *RuleGroup, payload *ruleGroupPayload) {
+	if e.logger != nil {
+		e.logger.Debug("Matched rule group", "group", rg.Name)
+	}
+
+	if (rg.Messenger != nil || rg.Forwarder != nil) && e.submitter != nil {
+		payloadStr := ""
+		if rg.Messenger != nil {
+			payloadStr = payload.String()
+		}
+		e.submitter.submitSideEffect(sideEffectRequest{
+			groupName:  rg.Name,
+			payload:    payload.Bytes(),
+			payloadStr: payloadStr,
+			messenger:  rg.Messenger,
+			forwarder:  rg.Forwarder,
+		})
+	}
+
+	if rg.Writer != nil {
+		if _, err := rg.Writer.Write(payload.frame); err != nil && e.logger != nil {
+			e.logger.Error("Failed to write audit log", "group", rg.Name, "error", err)
+		}
+		return
+	}
+
+	rg.Logger.Print(payload.String())
+}
+
+func (p *ruleGroupPayload) Bytes() []byte {
+	if !p.payloadReady {
+		p.payload = append([]byte(nil), p.frame...)
+		p.payloadReady = true
+	}
+	return p.payload
+}
+
+func (p *ruleGroupPayload) String() string {
+	if !p.payloadStrReady {
+		if p.payloadReady {
+			p.payloadStr = string(p.payload)
+		} else {
+			p.payloadStr = string(p.frame)
+		}
+		p.payloadStrReady = true
+	}
+	return p.payloadStr
+}
+
+func (rg *RuleGroup) shouldLog(auditLog *AuditLog) bool {
+	if len(rg.CompiledRules) == 0 {
+		return true
+	}
+	for _, compiledRule := range rg.CompiledRules {
+		output, err := expr.Run(compiledRule.Program, auditLog)
+		if err != nil {
+			continue
+		}
+		if match, ok := output.(bool); ok && match {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/auditserver/server.go
+++ b/pkg/auditserver/server.go
@@ -1,14 +1,12 @@
 package auditserver
 
 import (
-	"bytes"
 	"fmt"
 	json "github.com/bytedance/sonic"
 	"io"
 	"log"
 	"log/slog"
 	"os"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -18,7 +16,6 @@ import (
 	"github.com/ncode/vault-audit-filter/pkg/forwarder"
 	"github.com/ncode/vault-audit-filter/pkg/messaging"
 	"github.com/panjf2000/gnet/v2"
-	"github.com/spf13/viper"
 	"gopkg.in/natefinch/lumberjack.v2"
 )
 
@@ -134,9 +131,11 @@ type AuditServer struct {
 	*gnet.BuiltinEventEngine
 	logger                *slog.Logger
 	ruleGroups            []RuleGroup
+	ruleExecutor          ruleGroupExecutor
 	auditTransport        string
 	sideQueue             chan sideTask
 	sideDrops             atomic.Uint64
+	sideProcessor         *sideEffectProcessor
 	asyncEnqueueMode      string
 	asyncEnqueueTimeout   time.Duration
 	asyncWorkers          int
@@ -197,11 +196,7 @@ func (as *AuditServer) matchFrame(frame []byte) (matchResult, error) {
 	}
 
 	var matchedIndexes []int
-	for idx := range as.ruleGroups {
-		if as.ruleGroups[idx].shouldLog(auditLog) {
-			matchedIndexes = append(matchedIndexes, idx)
-		}
-	}
+	matchedIndexes = as.executor().Match(auditLog)
 	result := matchResult{
 		Matched:             len(matchedIndexes) > 0,
 		Log:                 *auditLog,
@@ -213,47 +208,7 @@ func (as *AuditServer) matchFrame(frame []byte) (matchResult, error) {
 }
 
 func (as *AuditServer) handleFrameWithResult(frame []byte, result matchResult) {
-
-	var payload []byte
-	var payloadStr string
-	payloadReady := false
-	payloadStrReady := false
-
-	for _, rgIdx := range result.matchedGroupIndexes {
-		rg := as.ruleGroups[rgIdx]
-
-		as.logger.Debug("Matched rule group", "group", rg.Name)
-
-		if rg.Messenger != nil || rg.Forwarder != nil {
-			if !payloadReady {
-				payload = append([]byte(nil), frame...)
-				payloadReady = true
-			}
-			if rg.Messenger != nil && !payloadStrReady {
-				payloadStr = string(payload)
-				payloadStrReady = true
-			}
-			_ = as.enqueueSide(sideTask{
-				groupName:  rg.Name,
-				payload:    payload,
-				payloadStr: payloadStr,
-				messenger:  rg.Messenger,
-				forwarder:  rg.Forwarder,
-			})
-		}
-
-		if rg.Writer != nil {
-			if _, err := rg.Writer.Write(frame); err != nil {
-				as.logger.Error("Failed to write audit log", "group", rg.Name, "error", err)
-			}
-		} else {
-			if payloadStrReady {
-				rg.Logger.Print(payloadStr)
-			} else {
-				rg.Logger.Print(string(frame))
-			}
-		}
-	}
+	as.executor().Execute(frame, result.matchedGroupIndexes)
 }
 
 func (as *AuditServer) handleFrame(frame []byte) gnet.Action {
@@ -276,157 +231,55 @@ func (as *AuditServer) React(frame []byte, _ gnet.Conn) (out []byte, action gnet
 }
 
 func (as *AuditServer) OnTraffic(c gnet.Conn) (action gnet.Action) {
-	frame, err := c.Next(-1)
-	if err != nil {
-		as.logger.Error("Error reading frame", "error", err)
-		return gnet.Close
-	}
-	if as.auditTransport == "tcp" {
-		var carryover []byte
-		if ctx := c.Context(); ctx != nil {
-			if b, ok := ctx.([]byte); ok {
-				carryover = b
-			}
-		}
-
-		remaining := as.handleTCPStream(frame, carryover)
-		if len(remaining) == 0 {
-			c.SetContext(nil)
-			return gnet.None
-		}
-		c.SetContext(append([]byte(nil), remaining...))
-		return gnet.None
-	}
-	return as.handleFrame(frame)
+	return newTransportAdapter(as.auditTransport, as.logger, as).OnTraffic(c)
 }
 
 func (as *AuditServer) handleTCPStream(frame []byte, carryover []byte) []byte {
-	buffer := append([]byte(nil), carryover...)
-	if len(frame) > 0 {
-		buffer = append(buffer, frame...)
-	}
-
-	for {
-		sep := bytes.IndexByte(buffer, '\n')
-		if sep < 0 {
-			return buffer
-		}
-
-		rawLine := buffer[:sep]
-		line := bytes.TrimSuffix(rawLine, []byte{'\r'})
-		if len(line) > 0 {
-			_ = as.handleFrame(line)
-		}
-
-		if sep == len(buffer)-1 {
-			buffer = buffer[:0]
-		} else {
-			buffer = buffer[sep+1:]
-		}
-	}
+	return newTransportAdapter("tcp", as.logger, as).handleTCPStream(frame, carryover)
 }
 
-func (rg *RuleGroup) shouldLog(auditLog *AuditLog) bool {
-	if len(rg.CompiledRules) == 0 {
-		return true
+func (as *AuditServer) executor() ruleGroupExecutor {
+	if as.ruleExecutor.groups != nil {
+		return as.ruleExecutor
 	}
-	for _, compiledRule := range rg.CompiledRules {
-		output, err := expr.Run(compiledRule.Program, auditLog)
-		if err != nil {
-			continue
-		}
-		if match, ok := output.(bool); ok && match {
-			return true
-		}
-	}
-	return false
+	return newRuleGroupExecutor(as.ruleGroups, as.logger, as)
 }
 
-func auditTransportProtocol(logger *slog.Logger) string {
-	protocol := strings.ToLower(strings.TrimSpace(viper.GetString("vault.audit_protocol")))
-	if protocol == "" {
-		protocol = "udp"
+func (as *AuditServer) submitSideEffect(req sideEffectRequest) bool {
+	if as.sideProcessor == nil {
+		return false
 	}
-
-	switch protocol {
-	case "udp", "tcp":
-		return protocol
-	default:
-		if logger != nil {
-			logger.Warn("Invalid vault.audit_protocol; using udp", "value", protocol)
-		}
-		return "udp"
-	}
+	return as.sideProcessor.Submit(req)
 }
 
-func New(logger *slog.Logger) (*AuditServer, error) {
+func (as *AuditServer) resolveSideTaskAdapters(groupName string) sideTaskAdapters {
+	for i := range as.ruleGroups {
+		if as.ruleGroups[i].Name == groupName {
+			return sideTaskAdapters{
+				messenger: as.ruleGroups[i].Messenger,
+				forwarder: as.ruleGroups[i].Forwarder,
+			}
+		}
+	}
+	return sideTaskAdapters{}
+}
+
+func New(logger *slog.Logger, runtimeSettings ...RuntimeSettings) (*AuditServer, error) {
 	if logger == nil {
 		logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	}
-
-	viper.SetDefault("async.queue_size", 20)
-	viper.SetDefault("async.workers", defaultSideWorkers)
-	viper.SetDefault("async.enqueue_mode", "drop")
-	viper.SetDefault("async.enqueue_timeout", "5ms")
-	viper.SetDefault("async.timeout", "5s")
-	viper.SetDefault("async.durable.enabled", false)
-	viper.SetDefault("async.durable.dir", "./.vault-audit-filter-sideeffects")
-	viper.SetDefault("async.retry.max_attempts", 3)
-	viper.SetDefault("async.retry.backoff", "100ms")
-
-	queueSize := viper.GetInt("async.queue_size")
-	if queueSize <= 0 {
-		queueSize = 20
-	}
-	workers := viper.GetInt("async.workers")
-	if workers < 0 {
-		workers = defaultSideWorkers
-	}
-	enqueueMode := strings.ToLower(strings.TrimSpace(viper.GetString("async.enqueue_mode")))
-	if enqueueMode == "" {
-		enqueueMode = "drop"
-	}
-	if enqueueMode != "drop" && enqueueMode != "wait" {
-		logger.Warn("Invalid async.enqueue_mode; using default", "value", enqueueMode)
-		enqueueMode = "drop"
-	}
-	rawEnqueueTimeout := viper.GetString("async.enqueue_timeout")
-	enqueueTimeout, err := time.ParseDuration(rawEnqueueTimeout)
-	if err != nil || enqueueTimeout <= 0 {
-		enqueueTimeout = 5 * time.Millisecond
-		logger.Warn("Invalid async.enqueue_timeout; using default", "value", rawEnqueueTimeout)
-	}
-	rawTimeout := viper.GetString("async.timeout")
-	asyncTimeout, err := time.ParseDuration(rawTimeout)
-	if err != nil {
-		asyncTimeout = 5 * time.Second
-		logger.Warn("Invalid async.timeout; using default", "value", rawTimeout)
-	}
-	durableEnabled := viper.GetBool("async.durable.enabled")
-	durableDir := strings.TrimSpace(viper.GetString("async.durable.dir"))
-	if durableDir == "" {
-		durableDir = "./.vault-audit-filter-sideeffects"
-	}
-	retryMaxAttempts := viper.GetInt("async.retry.max_attempts")
-	if retryMaxAttempts <= 0 {
-		retryMaxAttempts = 3
-	}
-	rawRetryBackoff := viper.GetString("async.retry.backoff")
-	retryBackoff, err := time.ParseDuration(rawRetryBackoff)
-	if err != nil || retryBackoff <= 0 {
-		retryBackoff = 100 * time.Millisecond
-		logger.Warn("Invalid async.retry.backoff; using default", "value", rawRetryBackoff)
+	if len(runtimeSettings) > 1 {
+		return nil, fmt.Errorf("expected at most one runtime settings value")
 	}
 
-	// Load rule groups from configuration
-	var ruleGroupConfigs []RuleGroupConfig
-	if err := viper.UnmarshalKey("rule_groups", &ruleGroupConfigs); err != nil {
-		logger.Error("Failed to load rule groups", "error", err)
-		return nil, fmt.Errorf("failed to load rule groups: %w", err)
+	settings := DefaultRuntimeSettings()
+	if len(runtimeSettings) == 1 {
+		settings = runtimeSettings[0]
 	}
+	settings = NormalizeRuntimeSettings(settings, logger)
 
 	var ruleGroups []RuleGroup
-	if len(ruleGroupConfigs) == 0 {
+	if len(settings.RuleGroups) == 0 {
 		defaultLogger := log.New(os.Stdout, "", 0)
 		ruleGroups = append(ruleGroups, RuleGroup{
 			Name:          "default",
@@ -434,7 +287,7 @@ func New(logger *slog.Logger) (*AuditServer, error) {
 			Logger:        defaultLogger,
 		})
 	} else {
-		for _, rgConfig := range ruleGroupConfigs {
+		for _, rgConfig := range settings.RuleGroups {
 			// Compile rules
 			var compiledRules []CompiledRule
 			for _, ruleStr := range rgConfig.Rules {
@@ -461,9 +314,9 @@ func New(logger *slog.Logger) (*AuditServer, error) {
 			var messenger messaging.Messenger
 			switch rgConfig.Messaging.Type {
 			case "slack":
-				messenger = messaging.NewSlackMessenger(rgConfig.Messaging.URL, rgConfig.Messaging.Token, rgConfig.Messaging.Channel, asyncTimeout)
+				messenger = messaging.NewSlackMessenger(rgConfig.Messaging.URL, rgConfig.Messaging.Token, rgConfig.Messaging.Channel, settings.Async.Timeout)
 			case "slack_webhook":
-				messenger = messaging.NewSlackWebhookMessenger(rgConfig.Messaging.WebhookURL, asyncTimeout)
+				messenger = messaging.NewSlackWebhookMessenger(rgConfig.Messaging.WebhookURL, settings.Async.Timeout)
 			default:
 				if rgConfig.Messaging.Type != "" {
 					logger.Error("Invalid messenger type", "type", rgConfig.Messaging.Type)
@@ -480,7 +333,7 @@ func New(logger *slog.Logger) (*AuditServer, error) {
 					return nil, fmt.Errorf("failed to create UDP forwarder: %w", err)
 				}
 				if udpFwd, ok := fwd.(*forwarder.UDPForwarder); ok {
-					udpFwd.SetTimeout(asyncTimeout)
+					udpFwd.SetTimeout(settings.Async.Timeout)
 				}
 			}
 
@@ -498,28 +351,44 @@ func New(logger *slog.Logger) (*AuditServer, error) {
 	server := &AuditServer{
 		logger:                logger,
 		ruleGroups:            ruleGroups,
-		auditTransport:        auditTransportProtocol(logger),
-		sideQueue:             make(chan sideTask, queueSize),
-		asyncEnqueueMode:      enqueueMode,
-		asyncEnqueueTimeout:   enqueueTimeout,
-		asyncWorkers:          workers,
-		asyncQueueSize:        queueSize,
-		asyncTimeout:          asyncTimeout,
-		asyncDurableEnabled:   durableEnabled,
-		asyncDurableDir:       durableDir,
-		asyncRetryMaxAttempts: retryMaxAttempts,
-		asyncRetryBackoff:     retryBackoff,
+		auditTransport:        settings.AuditProtocol,
+		asyncEnqueueMode:      settings.Async.EnqueueMode,
+		asyncEnqueueTimeout:   settings.Async.EnqueueTimeout,
+		asyncWorkers:          settings.Async.Workers,
+		asyncQueueSize:        settings.Async.QueueSize,
+		asyncTimeout:          settings.Async.Timeout,
+		asyncDurableEnabled:   settings.Async.Durable.Enabled,
+		asyncDurableDir:       settings.Async.Durable.Dir,
+		asyncRetryMaxAttempts: settings.Async.Retry.MaxAttempts,
+		asyncRetryBackoff:     settings.Async.Retry.Backoff,
 	}
-	if durableEnabled {
-		store, err := newFileSideTaskStore(durableDir)
+	server.ruleExecutor = newRuleGroupExecutor(ruleGroups, logger, server)
+	if settings.Async.Durable.Enabled {
+		store, err := newFileSideTaskStore(settings.Async.Durable.Dir)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create durable side task store: %w", err)
 		}
 		server.sideStore = store
 	}
-	server.startSideWorkers(workers)
-	if durableEnabled {
-		server.replayDurablePending()
+	server.sideProcessor = newSideEffectProcessor(sideEffectProcessorConfig{
+		logger:               logger,
+		queueSize:            settings.Async.QueueSize,
+		enqueueMode:          settings.Async.EnqueueMode,
+		enqueueTimeout:       settings.Async.EnqueueTimeout,
+		durableEnabled:       settings.Async.Durable.Enabled,
+		retryMaxAttempts:     settings.Async.Retry.MaxAttempts,
+		retryBackoff:         settings.Async.Retry.Backoff,
+		store:                server.sideStore,
+		adapterResolver:      server.resolveSideTaskAdapters,
+		mirrorDrops:          &server.sideDrops,
+		mirrorTaskSeq:        &server.sideTaskSeq,
+		mirrorQueue:          &server.sideQueue,
+		mirrorEnqueueMode:    &server.asyncEnqueueMode,
+		mirrorEnqueueTimeout: &server.asyncEnqueueTimeout,
+	})
+	server.sideProcessor.startWorkers(settings.Async.Workers)
+	if settings.Async.Durable.Enabled {
+		server.sideProcessor.replayDurablePending()
 	}
 	return server, nil
 }

--- a/pkg/auditserver/server.go
+++ b/pkg/auditserver/server.go
@@ -234,10 +234,6 @@ func (as *AuditServer) OnTraffic(c gnet.Conn) (action gnet.Action) {
 	return newTransportAdapter(as.auditTransport, as.logger, as).OnTraffic(c)
 }
 
-func (as *AuditServer) handleTCPStream(frame []byte, carryover []byte) []byte {
-	return newTransportAdapter("tcp", as.logger, as).handleTCPStream(frame, carryover)
-}
-
 func (as *AuditServer) executor() ruleGroupExecutor {
 	if as.ruleExecutor.groups != nil {
 		return as.ruleExecutor

--- a/pkg/auditserver/server_test.go
+++ b/pkg/auditserver/server_test.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -23,7 +24,6 @@ import (
 
 	"github.com/expr-lang/expr"
 	"github.com/panjf2000/gnet/v2"
-	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -77,6 +77,12 @@ func (b *lockedBuffer) String() string {
 	return b.buf.String()
 }
 
+func testRuntimeSettings(ruleGroups []RuleGroupConfig) RuntimeSettings {
+	settings := DefaultRuntimeSettings()
+	settings.RuleGroups = ruleGroups
+	return settings
+}
+
 func TestAuditServer_React(t *testing.T) {
 	// Create a temporary directory for log files
 	tempDir := t.TempDir()
@@ -101,9 +107,6 @@ func TestAuditServer_React(t *testing.T) {
 			},
 		},
 	}
-
-	// Initialize viper with the rule group configurations
-	viper.Set("rule_groups", ruleGroupConfigs)
 
 	for _, tt := range []struct {
 		name                string
@@ -206,7 +209,7 @@ func TestAuditServer_React(t *testing.T) {
 			logger := slog.New(slog.NewJSONHandler(logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
 			// Create the AuditServer
-			as, _ := New(logger)
+			as, _ := New(logger, testRuntimeSettings(ruleGroupConfigs))
 
 			// Set up mock messenger if needed
 			for i := range as.ruleGroups {
@@ -270,17 +273,14 @@ func TestAuditServer_React(t *testing.T) {
 }
 
 func TestMatchFrame(t *testing.T) {
-	viper.Reset()
-	viper.Set("rule_groups", []RuleGroupConfig{
+	as, err := New(nil, testRuntimeSettings([]RuleGroupConfig{
 		{
 			Name: "updates",
 			Rules: []string{
 				`Request.Operation in ["update", "create"] && Request.Path == "secret/data/config" && Auth.PolicyResults.Allowed == true`,
 			},
 		},
-	})
-
-	as, err := New(nil)
+	}))
 	require.NoError(t, err)
 
 	t.Run("matches and returns parsed log", func(t *testing.T) {
@@ -308,8 +308,7 @@ func TestMatchFrame(t *testing.T) {
 }
 
 func TestMatchFrame_UsesMatcherRulesForMatchGroups(t *testing.T) {
-	viper.Reset()
-	viper.Set("rule_groups", []RuleGroupConfig{
+	as, err := New(nil, testRuntimeSettings([]RuleGroupConfig{
 		{
 			Name:  "only_updates",
 			Rules: []string{`Request.Operation == "update" && Auth.PolicyResults.Allowed == true`},
@@ -318,9 +317,7 @@ func TestMatchFrame_UsesMatcherRulesForMatchGroups(t *testing.T) {
 			Name:  "all_reads",
 			Rules: []string{`Request.Operation == "read" && Auth.PolicyResults.Allowed == true`},
 		},
-	})
-
-	as, err := New(nil)
+	}))
 	require.NoError(t, err)
 
 	result, err := as.MatchFrame([]byte(`{"type":"request","time":"2024-01-01T00:00:00Z","request":{"operation":"read","path":"secret/data/config"},"auth":{"policy_results":{"allowed":true}}}`))
@@ -330,8 +327,7 @@ func TestMatchFrame_UsesMatcherRulesForMatchGroups(t *testing.T) {
 }
 
 func TestMatchFrame_ReportsAllMatchingGroupsInOrder(t *testing.T) {
-	viper.Reset()
-	viper.Set("rule_groups", []RuleGroupConfig{
+	as, err := New(nil, testRuntimeSettings([]RuleGroupConfig{
 		{
 			Name:  "first",
 			Rules: []string{`Request.Operation == "read" && Auth.PolicyResults.Allowed == true`},
@@ -344,9 +340,7 @@ func TestMatchFrame_ReportsAllMatchingGroupsInOrder(t *testing.T) {
 			Name:  "third",
 			Rules: []string{`Request.Operation == "read" && Request.Path == "secret/data/config" && Auth.PolicyResults.Allowed == true`},
 		},
-	})
-
-	as, err := New(nil)
+	}))
 	require.NoError(t, err)
 
 	result, err := as.MatchFrame([]byte(`{"type":"request","time":"2024-01-01T00:00:00Z","request":{"operation":"read","path":"secret/data/config"},"auth":{"policy_results":{"allowed":true}}}`))
@@ -356,17 +350,12 @@ func TestMatchFrame_ReportsAllMatchingGroupsInOrder(t *testing.T) {
 }
 
 func ExampleAuditServer_MatchFrame() {
-	viper.Reset()
-	defer viper.Reset()
-
-	viper.Set("rule_groups", []RuleGroupConfig{
+	as, err := New(nil, testRuntimeSettings([]RuleGroupConfig{
 		{
 			Name:  "writes",
 			Rules: []string{`Request.Operation == "update" && Auth.PolicyResults.Allowed == true`},
 		},
-	})
-
-	as, err := New(nil)
+	}))
 	if err != nil {
 		panic(err)
 	}
@@ -403,14 +392,11 @@ func TestNew(t *testing.T) {
 		},
 	}
 
-	// Initialize viper with the rule group configurations
-	viper.Set("rule_groups", ruleGroupConfigs)
-
 	// Capture logs
 	logBuffer := &lockedBuffer{}
 	logger := slog.New(slog.NewJSONHandler(logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	server, _ := New(logger)
+	server, _ := New(logger, testRuntimeSettings(ruleGroupConfigs))
 	if len(server.ruleGroups) != len(ruleGroupConfigs) {
 		t.Errorf("Expected %d rule groups, got %d", len(ruleGroupConfigs), len(server.ruleGroups))
 	}
@@ -439,8 +425,6 @@ func TestNew(t *testing.T) {
 }
 
 func TestNew_DefaultRuleGroup_WhenMissingOrEmpty(t *testing.T) {
-	viper.Reset()
-
 	// Missing rule_groups
 	server, err := New(nil)
 	require.NoError(t, err)
@@ -450,15 +434,12 @@ func TestNew_DefaultRuleGroup_WhenMissingOrEmpty(t *testing.T) {
 	assert.NotNil(t, server.ruleGroups[0].Logger)
 
 	// Empty rule_groups
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{})
-	server, err = New(nil)
+	server, err = New(nil, testRuntimeSettings(nil))
 	require.NoError(t, err)
 	require.Len(t, server.ruleGroups, 1)
 }
 
 func TestNew_AsyncDefaults(t *testing.T) {
-	viper.Reset()
 	server, err := New(nil)
 	require.NoError(t, err)
 	require.NotNil(t, server)
@@ -469,37 +450,75 @@ func TestNew_AsyncDefaults(t *testing.T) {
 	assert.Equal(t, 5*time.Second, server.asyncTimeout)
 }
 
-func TestNew_InvalidEnqueueModeFallsBackToDrop(t *testing.T) {
-	viper.Reset()
-	viper.Set("async.enqueue_mode", "invalid")
-	viper.Set("async.enqueue_timeout", "12ms")
+func TestNew_UsesExplicitRuntimeSettings(t *testing.T) {
+	settings := DefaultRuntimeSettings()
+	settings.AuditProtocol = "tcp"
+	settings.Async.QueueSize = 7
+	settings.Async.Workers = 0
+	settings.Async.EnqueueMode = "wait"
+	settings.Async.EnqueueTimeout = 11 * time.Millisecond
+	settings.Async.Timeout = 17 * time.Millisecond
+	settings.Async.Durable.Enabled = true
+	settings.Async.Durable.Dir = t.TempDir()
+	settings.Async.Retry.MaxAttempts = 5
+	settings.Async.Retry.Backoff = 23 * time.Millisecond
+	settings.RuleGroups = []RuleGroupConfig{{
+		Name: "explicit",
+		Rules: []string{
+			"Request.Operation == 'read'",
+		},
+		LogFile: LogFileConfig{
+			FilePath: filepath.Join(t.TempDir(), "explicit.log"),
+			MaxSize:  1,
+		},
+	}}
 
-	server, err := New(nil)
+	server, err := New(nil, settings)
+	require.NoError(t, err)
+	require.NotNil(t, server)
+	assert.Equal(t, "tcp", server.auditTransport)
+	assert.Equal(t, 7, server.asyncQueueSize)
+	assert.Equal(t, 0, server.asyncWorkers)
+	assert.Equal(t, "wait", server.asyncEnqueueMode)
+	assert.Equal(t, 11*time.Millisecond, server.asyncEnqueueTimeout)
+	assert.Equal(t, 17*time.Millisecond, server.asyncTimeout)
+	assert.True(t, server.asyncDurableEnabled)
+	assert.Equal(t, settings.Async.Durable.Dir, server.asyncDurableDir)
+	assert.Equal(t, 5, server.asyncRetryMaxAttempts)
+	assert.Equal(t, 23*time.Millisecond, server.asyncRetryBackoff)
+	require.Len(t, server.ruleGroups, 1)
+	assert.Equal(t, "explicit", server.ruleGroups[0].Name)
+}
+
+func TestNew_InvalidEnqueueModeFallsBackToDrop(t *testing.T) {
+	settings := DefaultRuntimeSettings()
+	settings.Async.EnqueueMode = "invalid"
+	settings.Async.EnqueueTimeout = 12 * time.Millisecond
+
+	server, err := New(nil, settings)
 	require.NoError(t, err)
 	assert.Equal(t, "drop", server.asyncEnqueueMode)
 	assert.Equal(t, 12*time.Millisecond, server.asyncEnqueueTimeout)
 }
 
 func TestSideQueue_DropsWhenFull(t *testing.T) {
-	viper.Reset()
-	viper.Set("async.queue_size", 1)
 	oldWorkers := defaultSideWorkers
 	defaultSideWorkers = 0
 	defer func() { defaultSideWorkers = oldWorkers }()
 
-	viper.Set("rule_groups", []map[string]interface{}{
+	settings := DefaultRuntimeSettings()
+	settings.Async.QueueSize = 1
+	settings.Async.Workers = 0
+	settings.RuleGroups = []RuleGroupConfig{
 		{
-			"name":     "rg",
-			"rules":    []string{"true"},
-			"log_file": map[string]interface{}{"file_path": "/tmp/test.log", "max_size": 1},
-			"messaging": map[string]interface{}{
-				"type":        "slack_webhook",
-				"webhook_url": "http://example.com",
-			},
+			Name:      "rg",
+			Rules:     []string{"true"},
+			LogFile:   LogFileConfig{FilePath: "/tmp/test.log", MaxSize: 1},
+			Messaging: Messaging{Type: "slack_webhook", WebhookURL: "http://example.com"},
 		},
-	})
+	}
 
-	srv, err := New(nil)
+	srv, err := New(nil, settings)
 	require.NoError(t, err)
 
 	frame := []byte(`{"type":"request","time":"2000-01-01T00:00:00Z","auth":{},"request":{},"response":{}}`)
@@ -510,21 +529,18 @@ func TestSideQueue_DropsWhenFull(t *testing.T) {
 }
 
 func TestReact_AsyncMessengerCalled(t *testing.T) {
-	viper.Reset()
-	viper.Set("async.queue_size", 10)
-	viper.Set("rule_groups", []map[string]interface{}{
+	settings := DefaultRuntimeSettings()
+	settings.Async.QueueSize = 10
+	settings.RuleGroups = []RuleGroupConfig{
 		{
-			"name":     "rg",
-			"rules":    []string{"true"},
-			"log_file": map[string]interface{}{"file_path": "/tmp/test.log", "max_size": 1},
-			"messaging": map[string]interface{}{
-				"type":        "slack_webhook",
-				"webhook_url": "http://example.com",
-			},
+			Name:      "rg",
+			Rules:     []string{"true"},
+			LogFile:   LogFileConfig{FilePath: "/tmp/test.log", MaxSize: 1},
+			Messaging: Messaging{Type: "slack_webhook", WebhookURL: "http://example.com"},
 		},
-	})
+	}
 
-	srv, err := New(nil)
+	srv, err := New(nil, settings)
 	require.NoError(t, err)
 
 	called := make(chan struct{}, 1)
@@ -547,22 +563,19 @@ func TestReact_AsyncMessengerCalled(t *testing.T) {
 }
 
 func TestNew_AsyncWorkersCanBeDisabled(t *testing.T) {
-	viper.Reset()
-	viper.Set("async.queue_size", 10)
-	viper.Set("async.workers", 0)
-	viper.Set("rule_groups", []map[string]interface{}{
+	settings := DefaultRuntimeSettings()
+	settings.Async.QueueSize = 10
+	settings.Async.Workers = 0
+	settings.RuleGroups = []RuleGroupConfig{
 		{
-			"name":     "rg",
-			"rules":    []string{"true"},
-			"log_file": map[string]interface{}{"file_path": "/tmp/test.log", "max_size": 1},
-			"messaging": map[string]interface{}{
-				"type":        "slack_webhook",
-				"webhook_url": "http://example.com",
-			},
+			Name:      "rg",
+			Rules:     []string{"true"},
+			LogFile:   LogFileConfig{FilePath: "/tmp/test.log", MaxSize: 1},
+			Messaging: Messaging{Type: "slack_webhook", WebhookURL: "http://example.com"},
 		},
-	})
+	}
 
-	srv, err := New(nil)
+	srv, err := New(nil, settings)
 	require.NoError(t, err)
 
 	called := make(chan struct{}, 1)
@@ -585,26 +598,23 @@ func TestNew_AsyncWorkersCanBeDisabled(t *testing.T) {
 }
 
 func TestNew_AsyncWorkersCanOverrideDefault(t *testing.T) {
-	viper.Reset()
-	viper.Set("async.queue_size", 10)
-	viper.Set("async.workers", 1)
-	viper.Set("rule_groups", []map[string]interface{}{
+	settings := DefaultRuntimeSettings()
+	settings.Async.QueueSize = 10
+	settings.Async.Workers = 1
+	settings.RuleGroups = []RuleGroupConfig{
 		{
-			"name":     "rg",
-			"rules":    []string{"true"},
-			"log_file": map[string]interface{}{"file_path": "/tmp/test.log", "max_size": 1},
-			"messaging": map[string]interface{}{
-				"type":        "slack_webhook",
-				"webhook_url": "http://example.com",
-			},
+			Name:      "rg",
+			Rules:     []string{"true"},
+			LogFile:   LogFileConfig{FilePath: "/tmp/test.log", MaxSize: 1},
+			Messaging: Messaging{Type: "slack_webhook", WebhookURL: "http://example.com"},
 		},
-	})
+	}
 
 	oldWorkers := defaultSideWorkers
 	defaultSideWorkers = 0
 	defer func() { defaultSideWorkers = oldWorkers }()
 
-	srv, err := New(nil)
+	srv, err := New(nil, settings)
 	require.NoError(t, err)
 
 	called := make(chan struct{}, 1)
@@ -627,56 +637,98 @@ func TestNew_AsyncWorkersCanOverrideDefault(t *testing.T) {
 }
 
 func TestEnqueueSide_DropMode_DropsImmediatelyWhenFull(t *testing.T) {
-	as := &AuditServer{
-		sideQueue: make(chan sideTask, 1),
-	}
-	as.sideQueue <- sideTask{}
+	processor := newSideEffectProcessor(sideEffectProcessorConfig{
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		queueSize: 1,
+	})
+	processor.queue <- sideTask{}
 
 	start := time.Now()
-	ok := as.enqueueSide(sideTask{})
+	ok := processor.Submit(sideEffectRequest{})
 	elapsed := time.Since(start)
 
 	assert.False(t, ok)
-	assert.Equal(t, uint64(1), as.sideDrops.Load())
+	assert.Equal(t, uint64(1), processor.Drops())
 	assert.Less(t, elapsed, 10*time.Millisecond)
 }
 
+func TestSideEffectProcessor_MirrorsDropAndTaskSequence(t *testing.T) {
+	var drops atomic.Uint64
+	var seq atomic.Uint64
+	var queue chan sideTask
+	var mode string
+	var timeout time.Duration
+
+	processor := newSideEffectProcessor(sideEffectProcessorConfig{
+		logger:               slog.New(slog.NewTextHandler(io.Discard, nil)),
+		queueSize:            1,
+		enqueueMode:          "wait",
+		enqueueTimeout:       7 * time.Millisecond,
+		mirrorDrops:          &drops,
+		mirrorTaskSeq:        &seq,
+		mirrorQueue:          &queue,
+		mirrorEnqueueMode:    &mode,
+		mirrorEnqueueTimeout: &timeout,
+	})
+
+	require.NotNil(t, queue)
+	assert.Equal(t, "wait", mode)
+	assert.Equal(t, 7*time.Millisecond, timeout)
+	id := processor.nextTaskID()
+	assert.True(t, strings.HasSuffix(id, "-1"))
+
+	processor.queue <- sideTask{}
+	ok := processor.Submit(sideEffectRequest{})
+	assert.False(t, ok)
+	assert.Equal(t, uint64(1), processor.Drops())
+	assert.Equal(t, uint64(1), drops.Load())
+}
+
+func TestSideEffectProcessor_DefaultQueueSize(t *testing.T) {
+	processor := newSideEffectProcessor(sideEffectProcessorConfig{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	assert.Equal(t, defaultAsyncQueueSize, cap(processor.queue))
+}
+
 func TestEnqueueSide_WaitMode_TimesOutWhenFull(t *testing.T) {
-	as := &AuditServer{
-		sideQueue:           make(chan sideTask, 1),
-		asyncEnqueueMode:    "wait",
-		asyncEnqueueTimeout: 30 * time.Millisecond,
-	}
-	as.sideQueue <- sideTask{}
+	processor := newSideEffectProcessor(sideEffectProcessorConfig{
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		queueSize:      1,
+		enqueueMode:    "wait",
+		enqueueTimeout: 30 * time.Millisecond,
+	})
+	processor.queue <- sideTask{}
 
 	start := time.Now()
-	ok := as.enqueueSide(sideTask{})
+	ok := processor.enqueue(sideTask{})
 	elapsed := time.Since(start)
 
 	assert.False(t, ok)
-	assert.Equal(t, uint64(1), as.sideDrops.Load())
+	assert.Equal(t, uint64(1), processor.Drops())
 	assert.GreaterOrEqual(t, elapsed, 25*time.Millisecond)
 }
 
 func TestEnqueueSide_WaitMode_EnqueuesWhenCapacityFrees(t *testing.T) {
-	as := &AuditServer{
-		sideQueue:           make(chan sideTask, 1),
-		asyncEnqueueMode:    "wait",
-		asyncEnqueueTimeout: 200 * time.Millisecond,
-	}
-	as.sideQueue <- sideTask{}
+	processor := newSideEffectProcessor(sideEffectProcessorConfig{
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		queueSize:      1,
+		enqueueMode:    "wait",
+		enqueueTimeout: 200 * time.Millisecond,
+	})
+	processor.queue <- sideTask{}
 
 	go func() {
 		time.Sleep(25 * time.Millisecond)
-		<-as.sideQueue
+		<-processor.queue
 	}()
 
 	start := time.Now()
-	ok := as.enqueueSide(sideTask{})
+	ok := processor.enqueue(sideTask{})
 	elapsed := time.Since(start)
 
 	assert.True(t, ok)
-	assert.Equal(t, uint64(0), as.sideDrops.Load())
+	assert.Equal(t, uint64(0), processor.Drops())
 	assert.GreaterOrEqual(t, elapsed, 20*time.Millisecond)
 	assert.Less(t, elapsed, 200*time.Millisecond)
 }
@@ -685,20 +737,20 @@ func TestEnqueueSide_DurableMode_PersistsWhenQueueFull(t *testing.T) {
 	store, err := newFileSideTaskStore(t.TempDir())
 	require.NoError(t, err)
 
-	as := &AuditServer{
-		logger:              slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
-		sideQueue:           make(chan sideTask, 1),
-		asyncDurableEnabled: true,
-		asyncRetryBackoff:   20 * time.Millisecond,
-		sideStore:           store,
-	}
-	as.sideQueue <- sideTask{}
+	processor := newSideEffectProcessor(sideEffectProcessorConfig{
+		logger:         slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		queueSize:      1,
+		durableEnabled: true,
+		retryBackoff:   20 * time.Millisecond,
+		store:          store,
+	})
+	processor.queue <- sideTask{}
 
-	ok := as.enqueueSide(sideTask{groupName: "g", payload: []byte("x"), payloadStr: "x"})
+	ok := processor.enqueue(sideTask{groupName: "g", payload: []byte("x"), payloadStr: "x"})
 	require.True(t, ok)
-	assert.Equal(t, uint64(0), as.sideDrops.Load())
+	assert.Equal(t, uint64(0), processor.Drops())
 
-	tasks, err := as.sideStore.Pending()
+	tasks, err := store.Pending()
 	require.NoError(t, err)
 	require.Len(t, tasks, 1)
 }
@@ -707,15 +759,15 @@ func TestProcessSideTask_DurableRetryToDeadLetter(t *testing.T) {
 	store, err := newFileSideTaskStore(t.TempDir())
 	require.NoError(t, err)
 
-	as := &AuditServer{
-		logger:                slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
-		sideQueue:             make(chan sideTask, 8),
-		asyncDurableEnabled:   true,
-		asyncRetryMaxAttempts: 2,
-		asyncRetryBackoff:     20 * time.Millisecond,
-		sideStore:             store,
-	}
-	as.startSideWorkers(1)
+	processor := newSideEffectProcessor(sideEffectProcessorConfig{
+		logger:           slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		queueSize:        8,
+		durableEnabled:   true,
+		retryMaxAttempts: 2,
+		retryBackoff:     20 * time.Millisecond,
+		store:            store,
+	})
+	processor.startWorkers(1)
 
 	task := sideTask{
 		id:         "task-1",
@@ -724,12 +776,12 @@ func TestProcessSideTask_DurableRetryToDeadLetter(t *testing.T) {
 		payloadStr: "x",
 		messenger:  &dummyMessenger{sendErr: errors.New("boom")},
 	}
-	require.NoError(t, as.sideStore.Save(task))
+	require.NoError(t, store.Save(task))
 
-	as.processSideTask(task)
+	processor.process(task)
 
 	require.Eventually(t, func() bool {
-		pending, err := as.sideStore.Pending()
+		pending, err := store.Pending()
 		if err != nil {
 			return false
 		}
@@ -746,30 +798,32 @@ func TestReplayDurablePending_ReplaysStoredTasks(t *testing.T) {
 	require.NoError(t, err)
 
 	msg := &dummyMessenger{}
-	as := &AuditServer{
-		logger:                slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
-		sideQueue:             make(chan sideTask, 8),
-		asyncDurableEnabled:   true,
-		asyncRetryMaxAttempts: 2,
-		asyncRetryBackoff:     10 * time.Millisecond,
-		sideStore:             store,
-		ruleGroups: []RuleGroup{{
-			Name:      "g",
-			Messenger: msg,
-		}},
-	}
-	as.startSideWorkers(1)
+	processor := newSideEffectProcessor(sideEffectProcessorConfig{
+		logger:           slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		queueSize:        8,
+		durableEnabled:   true,
+		retryMaxAttempts: 2,
+		retryBackoff:     10 * time.Millisecond,
+		store:            store,
+		adapterResolver: func(groupName string) sideTaskAdapters {
+			if groupName == "g" {
+				return sideTaskAdapters{messenger: msg}
+			}
+			return sideTaskAdapters{}
+		},
+	})
+	processor.startWorkers(1)
 
-	require.NoError(t, as.sideStore.Save(sideTask{id: "task-a", groupName: "g", payload: []byte("a"), payloadStr: "a"}))
-	require.NoError(t, as.sideStore.Save(sideTask{id: "task-b", groupName: "g", payload: []byte("b"), payloadStr: "b"}))
+	require.NoError(t, store.Save(sideTask{id: "task-a", groupName: "g", payload: []byte("a"), payloadStr: "a"}))
+	require.NoError(t, store.Save(sideTask{id: "task-b", groupName: "g", payload: []byte("b"), payloadStr: "b"}))
 
-	as.replayDurablePending()
+	processor.replayDurablePending()
 
 	require.Eventually(t, func() bool {
 		return msg.Calls() == 2
 	}, 2*time.Second, 25*time.Millisecond)
 
-	pending, err := as.sideStore.Pending()
+	pending, err := store.Pending()
 	require.NoError(t, err)
 	assert.Len(t, pending, 0)
 }
@@ -806,26 +860,18 @@ func TestNewWithoutLogger(t *testing.T) {
 }
 
 func TestNew_WithRuleGroups(t *testing.T) {
-	// Set up a mock configuration
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	settings := testRuntimeSettings([]RuleGroupConfig{
 		{
-			"name": "test_group",
-			"rules": []string{
+			Name: "test_group",
+			Rules: []string{
 				"Request.Operation == 'read'",
 			},
-			"log_file": map[string]interface{}{
-				"file_path": "/tmp/test.log",
-				"max_size":  10,
-			},
-			"forwarding": map[string]interface{}{
-				"enabled": true,
-				"address": "127.0.0.1:9000",
-			},
+			LogFile:    LogFileConfig{FilePath: "/tmp/test.log", MaxSize: 10},
+			Forwarding: ForwardingConfig{Enabled: true, Address: "127.0.0.1:9000"},
 		},
 	})
 
-	server, err := New(nil)
+	server, err := New(nil, settings)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, server)
@@ -836,47 +882,30 @@ func TestNew_WithRuleGroups(t *testing.T) {
 	assert.NotNil(t, server.ruleGroups[0].Forwarder)
 }
 
-func TestNew_WithInvalidRuleGroups(t *testing.T) {
-	// Set up an invalid configuration
-	viper.Reset()
-	viper.Set("rule_groups", "invalid_value")
-
+func TestNew_WithTooManyRuntimeSettings(t *testing.T) {
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	server, err := New(logger)
+	server, err := New(logger, DefaultRuntimeSettings(), DefaultRuntimeSettings())
 
 	assert.Error(t, err)
 	assert.Nil(t, server)
-	assert.Contains(t, err.Error(), "failed to load rule groups")
-
-	// Verify error was logged
-	logOutput := buf.String()
-	assert.Contains(t, logOutput, "Failed to load rule groups")
-	assert.Contains(t, logOutput, "ERROR")
+	assert.Contains(t, err.Error(), "expected at most one runtime settings")
 }
 
 func TestNew_WithValidForwarder(t *testing.T) {
-	// Set up a mock configuration with a valid forwarder address
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	settings := testRuntimeSettings([]RuleGroupConfig{
 		{
-			"name": "test_group",
-			"rules": []string{
+			Name: "test_group",
+			Rules: []string{
 				"Request.Operation == 'read'",
 			},
-			"log_file": map[string]interface{}{
-				"file_path": "/tmp/test.log",
-				"max_size":  10,
-			},
-			"forwarding": map[string]interface{}{
-				"enabled": true,
-				"address": "127.0.0.1:9000",
-			},
+			LogFile:    LogFileConfig{FilePath: "/tmp/test.log", MaxSize: 10},
+			Forwarding: ForwardingConfig{Enabled: true, Address: "127.0.0.1:9000"},
 		},
 	})
 
-	server, err := New(nil)
+	server, err := New(nil, settings)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, server)
@@ -885,29 +914,21 @@ func TestNew_WithValidForwarder(t *testing.T) {
 }
 
 func TestNew_WithInvalidForwarder(t *testing.T) {
-	// Set up a mock configuration with an invalid forwarder address
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	settings := testRuntimeSettings([]RuleGroupConfig{
 		{
-			"name": "test_group",
-			"rules": []string{
+			Name: "test_group",
+			Rules: []string{
 				"Request.Operation == 'read'",
 			},
-			"log_file": map[string]interface{}{
-				"file_path": "/tmp/test.log",
-				"max_size":  10,
-			},
-			"forwarding": map[string]interface{}{
-				"enabled": true,
-				"address": "invalid:address:9000",
-			},
+			LogFile:    LogFileConfig{FilePath: "/tmp/test.log", MaxSize: 10},
+			Forwarding: ForwardingConfig{Enabled: true, Address: "invalid:address:9000"},
 		},
 	})
 
 	var buf bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
 
-	server, err := New(logger)
+	server, err := New(logger, settings)
 
 	assert.Error(t, err)
 	assert.Nil(t, server)
@@ -920,26 +941,18 @@ func TestNew_WithInvalidForwarder(t *testing.T) {
 }
 
 func TestNew_WithDisabledForwarder(t *testing.T) {
-	// Set up a mock configuration with forwarding disabled
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{
+	settings := testRuntimeSettings([]RuleGroupConfig{
 		{
-			"name": "test_group",
-			"rules": []string{
+			Name: "test_group",
+			Rules: []string{
 				"Request.Operation == 'read'",
 			},
-			"log_file": map[string]interface{}{
-				"file_path": "/tmp/test.log",
-				"max_size":  10,
-			},
-			"forwarding": map[string]interface{}{
-				"enabled": false,
-				"address": "127.0.0.1:9000",
-			},
+			LogFile:    LogFileConfig{FilePath: "/tmp/test.log", MaxSize: 10},
+			Forwarding: ForwardingConfig{Enabled: false, Address: "127.0.0.1:9000"},
 		},
 	})
 
-	server, err := New(nil)
+	server, err := New(nil, settings)
 
 	assert.NoError(t, err)
 	assert.NotNil(t, server)
@@ -1099,9 +1112,6 @@ func TestAuditServer_React_WithForwarding(t *testing.T) {
 		},
 	}
 
-	// Initialize viper with the rule group configurations
-	viper.Set("rule_groups", ruleGroupConfigs)
-
 	testCases := []struct {
 		name              string
 		input             AuditLog
@@ -1182,7 +1192,7 @@ func TestAuditServer_React_WithForwarding(t *testing.T) {
 
 			// Create the AuditServer
 			logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
-			as, _ := New(logger)
+			as, _ := New(logger, testRuntimeSettings(ruleGroupConfigs))
 
 			// Replace the forwarders with our mocks
 			as.ruleGroups[0].Forwarder = mockForwarder1
@@ -1269,6 +1279,38 @@ type dummyForwarder struct {
 	calls      int
 }
 
+type captureSideEffects struct {
+	requests []sideEffectRequest
+}
+
+func (c *captureSideEffects) submitSideEffect(req sideEffectRequest) bool {
+	c.requests = append(c.requests, req)
+	return true
+}
+
+func attachTestSideProcessor(srv *AuditServer, queueSize, workers int) {
+	if queueSize <= 0 {
+		queueSize = 1
+	}
+	srv.sideProcessor = newSideEffectProcessor(sideEffectProcessorConfig{
+		logger:               srv.logger,
+		queueSize:            queueSize,
+		enqueueMode:          srv.asyncEnqueueMode,
+		enqueueTimeout:       srv.asyncEnqueueTimeout,
+		durableEnabled:       srv.asyncDurableEnabled,
+		retryMaxAttempts:     srv.asyncRetryMaxAttempts,
+		retryBackoff:         srv.asyncRetryBackoff,
+		store:                srv.sideStore,
+		adapterResolver:      srv.resolveSideTaskAdapters,
+		mirrorDrops:          &srv.sideDrops,
+		mirrorTaskSeq:        &srv.sideTaskSeq,
+		mirrorQueue:          &srv.sideQueue,
+		mirrorEnqueueMode:    &srv.asyncEnqueueMode,
+		mirrorEnqueueTimeout: &srv.asyncEnqueueTimeout,
+	})
+	srv.sideProcessor.startWorkers(workers)
+}
+
 type errWriter struct{}
 
 func (e errWriter) Write(_ []byte) (int, error) {
@@ -1308,6 +1350,44 @@ func (c *fakeTrafficConn) Context() any {
 
 func (c *fakeTrafficConn) SetContext(ctx any) {
 	c.ctx = ctx
+}
+
+type captureFrameHandler struct {
+	frames [][]byte
+}
+
+func (h *captureFrameHandler) handleFrame(frame []byte) gnet.Action {
+	h.frames = append(h.frames, append([]byte(nil), frame...))
+	return gnet.None
+}
+
+func TestTransportAdapter_TCPFrameExtraction(t *testing.T) {
+	handler := &captureFrameHandler{}
+	transport := newTransportAdapter("tcp", slog.New(slog.NewTextHandler(io.Discard, nil)), handler)
+
+	lineA := []byte(`{"type":"request","time":"a"}`)
+	lineB := []byte(`{"type":"request","time":"b"}`)
+	remaining := transport.handleTCPStream(append(append(append(lineA, '\n'), lineB...), '\r', '\n'), nil)
+
+	require.Empty(t, remaining)
+	require.Len(t, handler.frames, 2)
+	assert.Equal(t, lineA, handler.frames[0])
+	assert.Equal(t, lineB, handler.frames[1])
+
+	lineC := []byte(`{"type":"request","time":"c"}`)
+	carry := transport.handleTCPStream(lineC[:10], nil)
+	require.NotEmpty(t, carry)
+	carry = transport.handleTCPStream(append(lineC[10:], '\n'), carry)
+
+	require.Empty(t, carry)
+	require.Len(t, handler.frames, 3)
+	assert.Equal(t, lineC, handler.frames[2])
+}
+
+func TestTransportAdapter_NilHandlerCloses(t *testing.T) {
+	transport := newTransportAdapter("udp", slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+	action := transport.OnTraffic(&fakeTrafficConn{frame: auditFrame()})
+	assert.Equal(t, gnet.Close, action)
 }
 
 // minimal JSON frame that parses into an AuditLog
@@ -1416,9 +1496,8 @@ func TestReact_Branches(t *testing.T) {
 			srv := &AuditServer{
 				logger:     logger,
 				ruleGroups: []RuleGroup{tc.group},
-				sideQueue:  make(chan sideTask, 2),
 			}
-			srv.startSideWorkers(1)
+			attachTestSideProcessor(srv, 2, 1)
 
 			_, act := srv.React(frame, nil)
 			require.Equal(t, tc.wantAction, act)
@@ -1439,6 +1518,55 @@ func TestReact_Branches(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRuleGroupExecutor_ExecuteWritesAndSubmitsSideEffects(t *testing.T) {
+	frame := auditFrame()
+	writer := new(bytes.Buffer)
+	msg := &dummyMessenger{}
+	fwd := &dummyForwarder{}
+	submitter := &captureSideEffects{}
+	executor := newRuleGroupExecutor([]RuleGroup{{
+		Name:          "all",
+		CompiledRules: nil,
+		Writer:        writer,
+		Messenger:     msg,
+		Forwarder:     fwd,
+	}}, slog.New(slog.NewTextHandler(io.Discard, nil)), submitter)
+
+	indexes := executor.Match(&AuditLog{})
+	require.Equal(t, []int{0}, indexes)
+
+	executor.Execute(frame, indexes)
+
+	assert.Equal(t, string(frame), writer.String())
+	require.Len(t, submitter.requests, 1)
+	assert.Equal(t, "all", submitter.requests[0].groupName)
+	assert.Equal(t, frame, submitter.requests[0].payload)
+	assert.Equal(t, string(frame), submitter.requests[0].payloadStr)
+	assert.Same(t, msg, submitter.requests[0].messenger)
+	assert.Same(t, fwd, submitter.requests[0].forwarder)
+}
+
+func TestRuleGroupExecutor_ExecuteSkipsInvalidIndexes(t *testing.T) {
+	writer := new(bytes.Buffer)
+	executor := newRuleGroupExecutor([]RuleGroup{{
+		Name:   "all",
+		Writer: writer,
+	}}, slog.New(slog.NewTextHandler(io.Discard, nil)), nil)
+
+	executor.Execute(auditFrame(), []int{-1, 1})
+	assert.Empty(t, writer.String())
+}
+
+func TestRuleGroupPayload_StringUsesCopiedPayload(t *testing.T) {
+	frame := []byte("original")
+	payload := ruleGroupPayload{frame: frame}
+	copied := payload.Bytes()
+	frame[0] = 'O'
+
+	assert.Equal(t, "original", string(copied))
+	assert.Equal(t, "original", payload.String())
 }
 
 func TestReact_WriteErrorAndLoggerPayloadBranches(t *testing.T) {
@@ -1471,15 +1599,27 @@ func TestReact_WriteErrorAndLoggerPayloadBranches(t *testing.T) {
 				Writer:        nil,
 				Messenger:     msg,
 			}},
-			sideQueue: make(chan sideTask, 1),
 		}
-		srv.startSideWorkers(1)
+		attachTestSideProcessor(srv, 1, 1)
 
 		_, action := srv.React(frame, nil)
 		require.Equal(t, gnet.None, action)
 		require.Eventually(t, func() bool { return msg.Calls() == 1 }, time.Second, 10*time.Millisecond)
 		require.Contains(t, buf.String(), string(frame))
 	})
+}
+
+func TestAuditServer_SideEffectAndAdapterFallbackBranches(t *testing.T) {
+	srv := &AuditServer{
+		ruleGroups: []RuleGroup{{Name: "known", Messenger: &dummyMessenger{}, Forwarder: &dummyForwarder{}}},
+	}
+
+	assert.False(t, srv.submitSideEffect(sideEffectRequest{}))
+	assert.Equal(t, sideTaskAdapters{}, srv.resolveSideTaskAdapters("missing"))
+
+	adapters := srv.resolveSideTaskAdapters("known")
+	assert.NotNil(t, adapters.messenger)
+	assert.NotNil(t, adapters.forwarder)
 }
 
 func TestRuleGroup_shouldLog_RuntimeErrorContinues(t *testing.T) {
@@ -1521,62 +1661,51 @@ func TestAuditServer_HandleTCPStream(t *testing.T) {
 }
 
 func TestNew_AuditTransportConfiguration(t *testing.T) {
-	viper.Reset()
 	server, err := New(nil)
 	require.NoError(t, err)
 	assert.Equal(t, "udp", server.auditTransport)
 
-	viper.Reset()
-	viper.Set("vault.audit_protocol", "tcp")
-	server, err = New(nil)
+	settings := DefaultRuntimeSettings()
+	settings.AuditProtocol = "tcp"
+	server, err = New(nil, settings)
 	require.NoError(t, err)
 	assert.Equal(t, "tcp", server.auditTransport)
 
-	viper.Reset()
-	viper.Set("vault.audit_protocol", "invalid")
+	settings.AuditProtocol = "invalid"
 	logBuffer := new(bytes.Buffer)
 	logger := slog.New(slog.NewTextHandler(logBuffer, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	server, err = New(logger)
+	server, err = New(logger, settings)
 	require.NoError(t, err)
 	assert.Equal(t, "udp", server.auditTransport)
 	assert.Contains(t, logBuffer.String(), "Invalid vault.audit_protocol")
 }
 
 func TestNew_AsyncEnqueueModeBlankFallsBackToDrop(t *testing.T) {
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{})
-	viper.Set("async.enqueue_mode", "   ")
+	settings := DefaultRuntimeSettings()
+	settings.Async.EnqueueMode = "   "
 
-	server, err := New(nil)
+	server, err := New(nil, settings)
 	require.NoError(t, err)
 	assert.Equal(t, "drop", server.asyncEnqueueMode)
 }
 
 func TestNew_WithSlackMessengerAndDurableEnabled(t *testing.T) {
-	viper.Reset()
-	viper.Set("async.durable.enabled", true)
-	viper.Set("async.durable.dir", t.TempDir())
-	viper.Set("async.timeout", "17ms")
-	viper.Set("rule_groups", []map[string]interface{}{
+	settings := DefaultRuntimeSettings()
+	settings.Async.Durable.Enabled = true
+	settings.Async.Durable.Dir = t.TempDir()
+	settings.Async.Timeout = 17 * time.Millisecond
+	settings.RuleGroups = []RuleGroupConfig{
 		{
-			"name": "slack_group",
-			"rules": []string{
+			Name: "slack_group",
+			Rules: []string{
 				"true",
 			},
-			"log_file": map[string]interface{}{
-				"file_path": filepath.Join(t.TempDir(), "slack.log"),
-				"max_size":  1,
-			},
-			"messaging": map[string]interface{}{
-				"type":    "slack",
-				"url":     "https://example.invalid",
-				"token":   "tok",
-				"channel": "chan",
-			},
+			LogFile:   LogFileConfig{FilePath: filepath.Join(t.TempDir(), "slack.log"), MaxSize: 1},
+			Messaging: Messaging{Type: "slack", URL: "https://example.invalid", Token: "tok", Channel: "chan"},
 		},
-	})
+	}
 
-	server, err := New(nil)
+	server, err := New(nil, settings)
 	require.NoError(t, err)
 	require.NotNil(t, server.sideStore)
 	require.True(t, server.asyncDurableEnabled)
@@ -1585,48 +1714,47 @@ func TestNew_WithSlackMessengerAndDurableEnabled(t *testing.T) {
 }
 
 func TestNew_DurableStoreCreationFailure(t *testing.T) {
-	viper.Reset()
-	viper.Set("async.durable.enabled", true)
 	badBase := filepath.Join(t.TempDir(), "base-file")
 	require.NoError(t, os.WriteFile(badBase, []byte("x"), 0o600))
-	viper.Set("async.durable.dir", badBase)
-	viper.Set("rule_groups", []map[string]interface{}{})
+	settings := DefaultRuntimeSettings()
+	settings.Async.Durable.Enabled = true
+	settings.Async.Durable.Dir = badBase
 
-	server, err := New(nil)
+	server, err := New(nil, settings)
 	require.Error(t, err)
 	assert.Nil(t, server)
 	assert.Contains(t, err.Error(), "failed to create durable side task store")
 }
 
 func TestEnqueueSide_WaitMode_DefaultTimeoutBranch(t *testing.T) {
-	as := &AuditServer{
-		sideQueue:           make(chan sideTask, 1),
-		asyncEnqueueMode:    "wait",
-		asyncEnqueueTimeout: 0,
-	}
-	as.sideQueue <- sideTask{}
+	processor := newSideEffectProcessor(sideEffectProcessorConfig{
+		logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
+		queueSize:   1,
+		enqueueMode: "wait",
+	})
+	processor.queue <- sideTask{}
 
 	start := time.Now()
-	ok := as.enqueueSide(sideTask{})
+	ok := processor.enqueue(sideTask{})
 	elapsed := time.Since(start)
 
 	assert.False(t, ok)
 	assert.GreaterOrEqual(t, elapsed, 4*time.Millisecond)
-	assert.Equal(t, uint64(1), as.sideDrops.Load())
+	assert.Equal(t, uint64(1), processor.Drops())
 }
 
 func TestProcessSideTask_RetrySaveErrorBranch(t *testing.T) {
 	store := &errSideTaskStore{saveErr: errors.New("save failed")}
-	as := &AuditServer{
-		logger:                slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
-		sideQueue:             make(chan sideTask, 1),
-		asyncDurableEnabled:   true,
-		asyncRetryMaxAttempts: 3,
-		asyncRetryBackoff:     10 * time.Millisecond,
-		sideStore:             store,
-	}
+	processor := newSideEffectProcessor(sideEffectProcessorConfig{
+		logger:           slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		queueSize:        1,
+		durableEnabled:   true,
+		retryMaxAttempts: 3,
+		retryBackoff:     10 * time.Millisecond,
+		store:            store,
+	})
 
-	as.processSideTask(sideTask{
+	processor.process(sideTask{
 		id:         "task-r1",
 		groupName:  "g",
 		payload:    []byte("x"),
@@ -1742,19 +1870,25 @@ func (s *errSideTaskStore) Pending() ([]sideTask, error) {
 }
 
 func TestNew_AsyncInvalidConfigFallsBackToDefaults(t *testing.T) {
-	viper.Reset()
-	viper.Set("rule_groups", []map[string]interface{}{})
-	viper.Set("async.queue_size", 0)
-	viper.Set("async.workers", -3)
-	viper.Set("async.enqueue_mode", "invalid")
-	viper.Set("async.enqueue_timeout", "not-a-duration")
-	viper.Set("async.timeout", "also-bad")
-	viper.Set("async.durable.enabled", false)
-	viper.Set("async.durable.dir", "")
-	viper.Set("async.retry.max_attempts", 0)
-	viper.Set("async.retry.backoff", "bad")
+	settings := RuntimeSettings{
+		Async: AsyncSettings{
+			QueueSize:      0,
+			Workers:        -3,
+			EnqueueMode:    "invalid",
+			EnqueueTimeout: 0,
+			Timeout:        0,
+			Durable: DurableSettings{
+				Enabled: false,
+				Dir:     "",
+			},
+			Retry: RetrySettings{
+				MaxAttempts: 0,
+				Backoff:     0,
+			},
+		},
+	}
 
-	server, err := New(nil)
+	server, err := New(nil, settings)
 	require.NoError(t, err)
 	require.NotNil(t, server)
 	assert.Equal(t, 20, server.asyncQueueSize)
@@ -1769,34 +1903,34 @@ func TestNew_AsyncInvalidConfigFallsBackToDefaults(t *testing.T) {
 
 func TestEnqueueSide_DurableSaveFailureReturnsFalse(t *testing.T) {
 	store := &errSideTaskStore{saveErr: errors.New("save failed")}
-	as := &AuditServer{
-		logger:              slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
-		sideQueue:           make(chan sideTask, 1),
-		asyncDurableEnabled: true,
-		sideStore:           store,
-	}
+	processor := newSideEffectProcessor(sideEffectProcessorConfig{
+		logger:         slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		queueSize:      1,
+		durableEnabled: true,
+		store:          store,
+	})
 
-	ok := as.enqueueSide(sideTask{id: "task-1"})
+	ok := processor.enqueue(sideTask{id: "task-1"})
 	assert.False(t, ok)
-	assert.Equal(t, uint64(0), as.sideDrops.Load())
+	assert.Equal(t, uint64(0), processor.Drops())
 }
 
 func TestEnqueueSide_WaitMode_DurableTimeoutReturnsTrue(t *testing.T) {
 	store := &errSideTaskStore{}
-	as := &AuditServer{
-		logger:              slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
-		sideQueue:           make(chan sideTask, 1),
-		asyncEnqueueMode:    "wait",
-		asyncEnqueueTimeout: 2 * time.Millisecond,
-		asyncDurableEnabled: true,
-		asyncRetryBackoff:   1 * time.Millisecond,
-		sideStore:           store,
-	}
-	as.sideQueue <- sideTask{id: "occupied"}
+	processor := newSideEffectProcessor(sideEffectProcessorConfig{
+		logger:         slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo})),
+		queueSize:      1,
+		enqueueMode:    "wait",
+		enqueueTimeout: 2 * time.Millisecond,
+		durableEnabled: true,
+		retryBackoff:   1 * time.Millisecond,
+		store:          store,
+	})
+	processor.queue <- sideTask{id: "occupied"}
 
-	ok := as.enqueueSide(sideTask{id: "task-2"})
+	ok := processor.enqueue(sideTask{id: "task-2"})
 	assert.True(t, ok)
-	assert.Equal(t, uint64(0), as.sideDrops.Load())
+	assert.Equal(t, uint64(0), processor.Drops())
 }
 
 func TestFileSideTaskStore_Branches(t *testing.T) {
@@ -1836,15 +1970,15 @@ func TestFileSideTaskStore_Branches(t *testing.T) {
 func TestReplayDurablePending_NoStoreOrPendingError(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	asNoStore := &AuditServer{logger: logger}
-	asNoStore.replayDurablePending()
+	noStore := newSideEffectProcessor(sideEffectProcessorConfig{logger: logger, queueSize: 1})
+	noStore.replayDurablePending()
 
-	asErr := &AuditServer{
+	withErr := newSideEffectProcessor(sideEffectProcessorConfig{
 		logger:    logger,
-		sideQueue: make(chan sideTask, 1),
-		sideStore: &errSideTaskStore{pendingErr: errors.New("boom")},
-	}
-	asErr.replayDurablePending()
+		queueSize: 1,
+		store:     &errSideTaskStore{pendingErr: errors.New("boom")},
+	})
+	withErr.replayDurablePending()
 }
 
 func TestOnTraffic(t *testing.T) {

--- a/pkg/auditserver/server_test.go
+++ b/pkg/auditserver/server_test.go
@@ -1630,36 +1630,6 @@ func TestRuleGroup_shouldLog_RuntimeErrorContinues(t *testing.T) {
 	assert.True(t, rg.shouldLog(&AuditLog{}))
 }
 
-func TestAuditServer_HandleTCPStream(t *testing.T) {
-	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug}))
-	writer := new(bytes.Buffer)
-
-	as := &AuditServer{
-		logger: logger,
-		ruleGroups: []RuleGroup{
-			{Name: "default", Writer: writer},
-		},
-	}
-
-	stream := []byte(string(auditFrame()) + "\n" + string(auditFrame()) + "\r\n")
-	remaining := as.handleTCPStream(stream, nil)
-	require.Empty(t, remaining)
-
-	frameText := string(auditFrame())
-	assert.Equal(t, 2, strings.Count(writer.String(), frameText))
-
-	// split frame across reads and validate carryover behavior
-	full := string(auditFrame())
-	mid := len(full) / 2
-	carry := as.handleTCPStream([]byte(full[:mid]), nil)
-	require.NotEmpty(t, carry)
-
-	carry = as.handleTCPStream([]byte(full[mid:]+"\n"), carry)
-	require.Empty(t, carry)
-
-	assert.Equal(t, 3, strings.Count(writer.String(), frameText))
-}
-
 func TestNew_AuditTransportConfiguration(t *testing.T) {
 	server, err := New(nil)
 	require.NoError(t, err)

--- a/pkg/auditserver/transport.go
+++ b/pkg/auditserver/transport.go
@@ -1,0 +1,86 @@
+package auditserver
+
+import (
+	"bytes"
+	"log/slog"
+
+	"github.com/panjf2000/gnet/v2"
+)
+
+type frameHandler interface {
+	handleFrame([]byte) gnet.Action
+}
+
+type transportAdapter struct {
+	protocol string
+	logger   *slog.Logger
+	handler  frameHandler
+}
+
+func newTransportAdapter(protocol string, logger *slog.Logger, handler frameHandler) transportAdapter {
+	return transportAdapter{
+		protocol: protocol,
+		logger:   logger,
+		handler:  handler,
+	}
+}
+
+func (t transportAdapter) OnTraffic(c gnet.Conn) gnet.Action {
+	frame, err := c.Next(-1)
+	if err != nil {
+		if t.logger != nil {
+			t.logger.Error("Error reading frame", "error", err)
+		}
+		return gnet.Close
+	}
+	if t.protocol == "tcp" {
+		var carryover []byte
+		if ctx := c.Context(); ctx != nil {
+			if b, ok := ctx.([]byte); ok {
+				carryover = b
+			}
+		}
+
+		remaining := t.handleTCPStream(frame, carryover)
+		if len(remaining) == 0 {
+			c.SetContext(nil)
+			return gnet.None
+		}
+		c.SetContext(append([]byte(nil), remaining...))
+		return gnet.None
+	}
+	return t.handleFrame(frame)
+}
+
+func (t transportAdapter) handleTCPStream(frame []byte, carryover []byte) []byte {
+	buffer := append([]byte(nil), carryover...)
+	if len(frame) > 0 {
+		buffer = append(buffer, frame...)
+	}
+
+	for {
+		sep := bytes.IndexByte(buffer, '\n')
+		if sep < 0 {
+			return buffer
+		}
+
+		rawLine := buffer[:sep]
+		line := bytes.TrimSuffix(rawLine, []byte{'\r'})
+		if len(line) > 0 {
+			_ = t.handleFrame(line)
+		}
+
+		if sep == len(buffer)-1 {
+			buffer = buffer[:0]
+		} else {
+			buffer = buffer[sep+1:]
+		}
+	}
+}
+
+func (t transportAdapter) handleFrame(frame []byte) gnet.Action {
+	if t.handler == nil {
+		return gnet.Close
+	}
+	return t.handler.handleFrame(frame)
+}

--- a/pkg/vault/vault.go
+++ b/pkg/vault/vault.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
+	"strings"
 
 	vault "github.com/hashicorp/vault/api"
 )
@@ -40,6 +42,14 @@ type CertAuth struct {
 type JWTAuth struct {
 	Role string
 	JWT  string
+}
+
+type SocketAuditDeviceSpec struct {
+	Path        string
+	Address     string
+	Protocol    string
+	Description string
+	LogRaw      bool
 }
 
 func (t TokenAuth) Authenticate(client *vault.Client) error {
@@ -164,4 +174,18 @@ func (vc *VaultClient) EnableAuditDevice(path, type_, description string, option
 	}
 
 	return nil
+}
+
+func (vc *VaultClient) EnableSocketAuditDevice(spec SocketAuditDeviceSpec) error {
+	protocol := strings.ToLower(strings.TrimSpace(spec.Protocol))
+	if protocol == "" {
+		protocol = "udp"
+	}
+
+	return vc.EnableAuditDevice(spec.Path, "socket", spec.Description, map[string]string{
+		"address":     spec.Address,
+		"socket_type": protocol,
+		"description": spec.Description,
+		"log_raw":     strconv.FormatBool(spec.LogRaw),
+	})
 }

--- a/pkg/vault/vault_test.go
+++ b/pkg/vault/vault_test.go
@@ -300,6 +300,82 @@ func TestEnableAuditDevice_ListAuditError(t *testing.T) {
 	assert.Contains(t, err.Error(), "failed to list audit devices")
 }
 
+func TestEnableSocketAuditDevice(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sys/audit":
+			assert.Equal(t, http.MethodGet, r.Method)
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"data":{}}`))
+		case "/v1/sys/audit/socket-audit":
+			assert.Equal(t, http.MethodPut, r.Method)
+			var payload struct {
+				Type        string                 `json:"type"`
+				Description string                 `json:"description"`
+				Options     map[string]interface{} `json:"options"`
+			}
+			err := json.NewDecoder(r.Body).Decode(&payload)
+			assert.NoError(t, err)
+			assert.Equal(t, "socket", payload.Type)
+			assert.Equal(t, "Socket audit", payload.Description)
+			assert.Equal(t, map[string]interface{}{
+				"address":     "127.0.0.1:1269",
+				"socket_type": "tcp",
+				"description": "Socket audit",
+				"log_raw":     "true",
+			}, payload.Options)
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("Unexpected request to %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, _ := vault.NewClient(&vault.Config{Address: server.URL})
+	vaultClient := &VaultClient{client}
+
+	err := vaultClient.EnableSocketAuditDevice(SocketAuditDeviceSpec{
+		Path:        "socket-audit",
+		Address:     "127.0.0.1:1269",
+		Protocol:    "tcp",
+		Description: "Socket audit",
+		LogRaw:      true,
+	})
+	assert.NoError(t, err)
+}
+
+func TestEnableSocketAuditDevice_DefaultProtocolAndRawPolicy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/sys/audit":
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"data":{}}`))
+		case "/v1/sys/audit/socket-audit":
+			var payload struct {
+				Options map[string]interface{} `json:"options"`
+			}
+			err := json.NewDecoder(r.Body).Decode(&payload)
+			assert.NoError(t, err)
+			assert.Equal(t, "udp", payload.Options["socket_type"])
+			assert.Equal(t, "false", payload.Options["log_raw"])
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			t.Fatalf("Unexpected request to %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client, _ := vault.NewClient(&vault.Config{Address: server.URL})
+	vaultClient := &VaultClient{client}
+
+	err := vaultClient.EnableSocketAuditDevice(SocketAuditDeviceSpec{
+		Path:        "socket-audit",
+		Address:     "127.0.0.1:1269",
+		Description: "Socket audit",
+	})
+	assert.NoError(t, err)
+}
+
 func TestVaultClient_Operations(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Summary

- Replace Viper-coupled audit server construction with typed runtime settings and normalization seams.
- Split audit server responsibilities across rule-group execution, side-effect processing, and transport adaptation.
- Add typed Vault socket audit device setup helpers and refactor integration tests around reusable listeners/client setup.
- Complete the deepen-audit-architecture-seams OpenSpec change artifacts and tasks.

## Impact

This keeps runtime behavior compatible while making the audit server easier to test and reason about at configuration, transport, rule evaluation, and async side-effect boundaries.

## Validation

- OpenSpec strict validation for deepen-audit-architecture-seams.
- Go fmt.
- Go vet.
- Race-enabled unit tests across all packages.
- Full coverage run with cover function report.
- Integration compile check.
- Full race-enabled integration suite with AUDIT_HOST=host.docker.internal.
- Auditserver benchmark comparison for React, MatchFrame, and ShouldLog.
